### PR TITLE
Fix Gatsby socket errors in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,12 @@ version: "3.8"
 services:
   app:
     command: npm run start -- --host 0.0.0.0
+    environment:
+      - INTERNAL_STATUS_PORT=8001
     image: node:14-alpine
     ports:
       - 8000:8000
+      - 8001:8001
     volumes:
       - .:/usr/src/app:delegated
     working_dir: /usr/src/app


### PR DESCRIPTION
This fixes the errors seen in the development server where it will repeatedly fail to connect to the randomized socket. This is really noticeable when you have the developer's console open, since it just starts filling up with errors.

Fortunately, https://github.com/gatsbyjs/gatsby/pull/25862 was created very recently to help us set a fixed port for the socket.