### PR TITLE
Set up staging deployment for new site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - new-master
+  workflow_dispatch:
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check build
+        run: npm run build
+
+      - name: Upload to AWS S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: staging.gatsby.sheltertech.org
+          AWS_ACCESS_KEY_ID: AKIASEI57EDUBSIVCZJX
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-east-1'
+          SOURCE_DIR: 'public'


### PR DESCRIPTION
This adds a GitHub Action workflow that runs when we merge into the `new-master` branch. It performs a build of the website static files with Gatsby, and then it uploads them to an AWS S3 bucket I created.

For now, I just created a brand new bucket named `staging.gatsby.sheltertech.org`, since I didn't want to touch any of the existing ones. I also created a new IAM user named `github-cicd` and added its credentials to GitHub.

When we eventually have this replace the `master` branch (or maybe the [`main` branch](https://github.com/github/renaming)), we'll need to update a line in the GitHub Action in order to have it deploy when that branch is updated.

I have a test deployment at http://staging.gatsby.sheltertech.org.s3-website-us-east-1.amazonaws.com/ from me testing on a different branch name, but that should show you roughly what to expect.