### PR TITLE
Minor cleanups

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["airbnb", "plugin:prettier/recommended"],
+  extends: ["airbnb", "plugin:prettier/recommended", "prettier/react"],
   env: {
     node: true,
     es6: true,

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -60,7 +60,7 @@ const Links = ({ withBlog }) => (
         Blog
       </a>
     )}
-    <Link className="donate-button" href="/donate">
+    <Link className="donate-button" to="/donate">
       Donate
     </Link>
   </>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+import Layout from "../layouts/Layout";
+
+const Page = () => (
+  <div className="content">
+    <div className="content-bg" />
+    <div className="content--header">
+      <h2>Page not found</h2>
+      <h3>Sorry, we couldn&apos;t find the page you were looking&nbsp;for.</h3>
+    </div>
+  </div>
+);
+
+export default () => (
+  <Layout>
+    <Page />
+  </Layout>
+);


### PR DESCRIPTION
This PR addresses a couple minor things I wanted to fix up.

https://github.com/ShelterTechSF/sheltertech.org/commit/a84d20c358f1917fb2633ffad8981bd63d3a245e slightly modifies the ESLint rules so that the `prettier/react` rules are included. This is similar to the `plugin:prettier/recommended` rules, which disable any ESLint rules that are in conflict with Prettier, except that `prettier/react` will specifically disable React rules. I was hitting an error in another branch where I could not simultaneously satisfy Prettier and Airbnb's rules, causing me to search the web and figure out that we should also add this ruleset.

https://github.com/ShelterTechSF/sheltertech.org/commit/64de272aa270472389ac13d22c5f9e0c8bf1c1b3 changes a stray `href` prop to `to` in a `<GatsbyLink>` component, which was causing PropType errors in the browser. TODO: Add some CI tests that fail if we fail any PropType checks.

https://github.com/ShelterTechSF/sheltertech.org/commit/ca477ddb8514a3f408969d3ab551dc274e522105 Adds a basic 404 page, which will silence the annoying Gatsby warnings about not having a 404 page defined. cc @derekfidler on this one, since I just created a basic page, since our old site doesn't apparently have a 404 page. We'll probably need a new design for the 404 page for the new site as well.

<img width="1353" alt="Screen Shot 2020-09-09 at 12 19 32 PM" src="https://user-images.githubusercontent.com/1002748/92643508-bee64680-f296-11ea-8622-60e0759d5cc2.png">