### PR TITLE
Fix CSS for event cards.

### DIFF
--- a/src/components/pages/events/EventsList.js
+++ b/src/components/pages/events/EventsList.js
@@ -7,8 +7,8 @@ import UPCOMING_EVENTS from "./data/EventsList";
 const EVENTS_LIST = UPCOMING_EVENTS.filter((n) => n && n.show);
 
 const EventsItem = ({ event: n }) => (
-  <li className="event-card">
-    <a href={n.link} target="_blank" rel="noreferrer">
+  <a className="event-card-link" href={n.link} target="_blank" rel="noreferrer">
+    <div className="event-card">
       <p className="event-card--cost">{n.cost}</p>
       <img className="event-card--image" src={n.img} alt={n.description} />
       <div className="event-card--details">
@@ -19,8 +19,8 @@ const EventsItem = ({ event: n }) => (
         </div>
         <small>{n.location}</small>
       </div>
-    </a>
-  </li>
+    </div>
+  </a>
 );
 
 EventsItem.propTypes = {
@@ -39,7 +39,9 @@ const EventsList = () => (
     {EVENTS_LIST.filter((n) => n && n.show)
       .reverse()
       .map((n) => (
-        <EventsItem key={n.id} event={n} />
+        <li className="events-list-item">
+          <EventsItem key={n.id} event={n} />
+        </li>
       ))}
   </ul>
 );

--- a/src/components/pages/events/EventsList.scss
+++ b/src/components/pages/events/EventsList.scss
@@ -6,6 +6,25 @@
   width: 90vw;
 }
 
+.events-list-item {
+  margin: 10px;
+  overflow: hidden;
+  position: relative;
+  width: 320px;
+}
+
+/* Unset styles applied globally to the <a> tag that do not make sense when the
+ * <a> tag wraps other elements and not just text.
+ */
+.event-card-link {
+  color: inherit;
+
+  &:hover {
+    position: initial;
+    top: initial;
+  }
+}
+
 .event-card {
   background-color: #fff;
   border: 1px solid #cfcfcf;
@@ -14,10 +33,6 @@
   display: flex;
   flex: 0 0 auto;
   flex-direction: column;
-  margin: 10px;
-  overflow: hidden;
-  position: relative;
-  width: 320px;
 }
 
 .event-card--cost {

--- a/src/components/pages/events/PastEventsList.js
+++ b/src/components/pages/events/PastEventsList.js
@@ -7,8 +7,8 @@ import PAST_EVENTS from "./data/PastEventsList";
 const EVENTS_LIST = PAST_EVENTS.filter((n) => n && n.show);
 
 const EventsItem = ({ event: n }) => (
-  <li className="event-card">
-    <a href={n.link} target="_blank" rel="noreferrer">
+  <a className="event-card-link" href={n.link} target="_blank" rel="noreferrer">
+    <div className="event-card">
       <p className="event-card--cost">{n.cost}</p>
       <img className="event-card--image" src={n.img} alt={n.description} />
       <div className="event-card--details">
@@ -19,8 +19,8 @@ const EventsItem = ({ event: n }) => (
         </div>
         <small>{n.location}</small>
       </div>
-    </a>
-  </li>
+    </div>
+  </a>
 );
 
 EventsItem.propTypes = {
@@ -37,7 +37,9 @@ EventsItem.propTypes = {
 const PastEventsList = () => (
   <ul className="events-list">
     {EVENTS_LIST.filter((n) => n && n.show).map((n) => (
-      <EventsItem key={n.id} event={n} />
+      <li className="events-list-item">
+        <EventsItem key={n.id} event={n} />
+      </li>
     ))}
   </ul>
 );


### PR DESCRIPTION
This restores the original colors and hover style, which were getting altered by the global `<a>` tag styles. @davidagustin and I noticed that without these fixes, the text in the event cards were getting a blue color and they had an odd on-hover style applied, which were coming from the global `<a>` tag.

This was probably originally caused by me changing the `onClick` event handlers on the cards with an `<a>` tag wrapping the whole element, since the former was causing lint errors related to accessibility (a11y).