### PR TITLE
Add production deployment workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,37 @@
+name: Deploy Production
+on:
+  workflow_dispatch:
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check build
+        run: npm run build
+
+      - name: Upload to AWS S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: www.sheltertech.org
+          AWS_ACCESS_KEY_ID: AKIASEI57EDUBSIVCZJX
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-east-1'
+          SOURCE_DIR: 'public'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,8 +1,8 @@
-name: Deploy
+name: Deploy Staging
 on:
   push:
     branches:
-      - new-master
+      - main
   workflow_dispatch:
 jobs:
   deploy:
@@ -33,7 +33,7 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
-          AWS_S3_BUCKET: staging.gatsby.sheltertech.org
+          AWS_S3_BUCKET: staging.sheltertech.org
           AWS_ACCESS_KEY_ID: AKIASEI57EDUBSIVCZJX
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'us-east-1'


### PR DESCRIPTION
This adds a new production deployment workflow from GitHub. I can add documentation on this to the README, but I'd like to test this out first. It's a bit hard to test this without just merging it in, so I'm going to do this, but I can create a followup PR that documents both the staging and production deployment mechanisms.