### PR TITLE
Restructure docs and add docs on the component design system

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ For more specific documentation, visit one of the pages below:
 
 - [Getting Started Guide][]
 - [Command-Line Quick Reference][]
+- [Component Design System][]
 - [How To Deploy][]
 
 [Getting Started Guide]: ./docs/getting-started.md
 [Command-Line Quick Reference]: ./docs/command-line-quick-reference.md
+[Component Design System]: ./docs/component-design-system.md
 [How To Deploy]: ./docs/how-to-deploy.md

--- a/README.md
+++ b/README.md
@@ -2,108 +2,14 @@
 
 > Created with [Gatsby](https://www.gatsbyjs.org/) with content managed in [Prismic](https://prismic.io)
 
+This repository contains the source code to the sheltertech.org website. To get
+the code running for the first team, please see the [Getting Started Guide][].
+For more specific documentation, visit one of the pages below:
 
-## Development Environment Setup
+- [Getting Started Guide][]
+- [Command-Line Quick Reference][]
+- [How To Deploy][]
 
-### Requirements
-
-Docker Desktop
-
-Follow the [Docker installation instructions](https://www.docker.com/get-started) for your OS.
-
-### Installing dependencies
-
-This only needs to be run once on first setup, and once any time the
-dependencies in package.json change.
-
-```sh
-$ docker-compose run --rm app npm install
-```
-
-
-## Gatsby Commands
-
-Gatsby is a React-based framework for generating static websites. The following
-are common commands you will use while developing the website.
-
-### Start Gatsby development web server
-
-```sh
-$ docker-compose up app
-```
-
-This will start the development web server at http://localhost:8000. The
-development server will automatically refresh your browser when any source file
-is modified.
-
-Press Ctrl + C to exit the development web server.
-
-### Build production site bundle
-
-```sh
-$ docker-compose run --rm app npm run build
-```
-
-This command will build a bundle of static files that can be deployed directly
-to a static web server host. The files will be located in the `./public`
-directory.
-
-
-## Storybook Commands
-
-[Storybook](https://storybook.js.org/) is a tool for developing reusable UI
-components. When developing a new component, it is recommended to first develop
-it in Storybook in order to encourage building it as a modular, isolated component
-before including it in the Gatsby-based site.
-
-### Start Storybook development web server
-
-```sh
-$ docker-compose up storybook
-```
-
-This will start the development web server at http://localhost:6006. The
-development server will automatically refresh your browser when any source file
-is modified.
-
-
-## General Commands
-
-### Run code lint checks
-
-```sh
-# Run this to automatically fix lint issues
-$ docker-compose run --rm app npm run lint:fix
-
-# Run this to just check for lint issues without fixing them
-$ docker-compose run --rm app npm run lint
-```
-
-
-## Deployments
-
-sheltertech.org has two deployment environments: staging.sheltertech.org and
-www.sheltertech.org. Both are hosted on [AWS S3](https://aws.amazon.com/s3/)
-buckets, and the deployments are both done via
-[GitHub Actions](https://docs.github.com/en/actions).
-
-Staging deployments are automatically triggered when a pull request is merged
-into the `main` branch.
-
-Production deployments must be manually triggered from the GitHub web interface.
-To deploy, click on the
-[Actions](https://github.com/ShelterTechSF/sheltertech.org/actions) tab from any
-GitHub page within the sheltertech.org repository, and then click on the
-[Deploy Production](https://github.com/ShelterTechSF/sheltertech.org/actions?query=workflow%3A%22Deploy+Production%22)
-workflow on the left side bar. Then click the **Run workflow** button on the
-right side, select the `main` branch, and then click the green **Run workflow**
-button. After the workflow finishes running, you should see the updated site at
-www.sheltertech.org.
-
-![Deploy Production](./docs/deploy-production.png)
-
-
-## Change content in Site
-
-> [ShelterTech Content in Prismic](https://sheltertech.prismic.io/)
-
+[Getting Started Guide]: ./docs/getting-started.md
+[Command-Line Quick Reference]: ./docs/command-line-quick-reference.md
+[How To Deploy]: ./docs/how-to-deploy.md

--- a/docs/command-line-quick-reference.md
+++ b/docs/command-line-quick-reference.md
@@ -1,0 +1,56 @@
+# Command-line Quick Reference
+
+This document lists commands that commonly used during development.
+
+## Gatsby Commands
+
+### Start Gatsby development web server
+
+```sh
+$ docker-compose up app
+```
+
+### Build production site bundle
+
+```sh
+$ docker-compose run --rm app npm run build
+```
+
+
+## Storybook Commands
+
+### Start Storybook development web server
+
+```sh
+$ docker-compose up storybook
+```
+
+
+## General Commands
+
+### Install dependencies
+
+```sh
+$ docker-compose run --rm app npm install
+```
+
+You may need to rerun this command if the dependencies have been changed since
+the last time you installed them.
+
+### Run code lint checks
+
+```sh
+# Run this to automatically fix lint issues
+$ docker-compose run --rm app npm run lint:fix
+```
+
+There are six variants of the command in case if you want to run something more
+specific. The commands are:
+
+- `lint:fix` - Automatically fix both CSS and JavaScript lint issues. Note that
+  if an error is encountered in CSS, it will not run the JavaScript lint check.
+- `lint` - Check, but do not fix, both CSS and JavaScript lint issues
+- `stylelint:fix` - Automatically fix CSS lint issues
+- `stylelint` - Check, but do not fix, CSS lint issues
+- `eslint:fix` - Automatically fix JavaScript lint issues
+- `eslint` - Check, but do not fix, JavaScript lint issues

--- a/docs/component-design-system.md
+++ b/docs/component-design-system.md
@@ -1,0 +1,90 @@
+# Component Design System
+
+Note: This is a work-in-progress document. The details may change as we try
+applying this system and revise the design over time.
+
+This system is based on a three-layer hierarchy of components, where each layer
+has a unique set of responsibilities. The division of responsibilities is
+derived from the HTML layout algorithm, where the rules of positioning and the
+cascade of styles from parent and child elements influences how we define the
+boundaries between the layers.
+
+
+## A short primer on the HTML layout algorithm
+
+HTML has two broad categories of elements: block elements and inline
+elements. Block elements roughly correspond to rectangular sections of a page,
+while inline elements roughly correspond to elements that flow with text. A
+`<div>` is a generic block element while a `<span>` is a generic inline element.
+
+By default, without additional CSS styling, block elements have a width that
+spans the entire width of its parent and a height that spans the height of its
+internal content. A block element therefore takes up the entire width of a "row"
+while it stretches vertically to fit all the content within it. Sibling block
+elements are stacked vertically, with the later siblings place immediately after
+the earlier ones.
+
+Inline elements, by contrast, only take up as much space as its internal
+content. They can even take non-contiguous rectangular sections of a page if it
+wraps from one row of text to the next. Inline elements act as if they were
+text, hence they are laid out _inline_ with text.
+
+A parent element constrains the layout of its children, and some of the newer
+CSS `display` property values can describe alternative ways of laying out
+children compared to the default layout described above. In particular `flex`
+and `grid` provide rich ways of precisely laying out children by dividing up the
+space available in the parent in different ways.
+
+
+See Mozilla Developer Network's article on
+[Block and inline layout in normal flow](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)
+for figures and more information.
+
+
+## Design System
+
+All UI components in the sheltertech.org will fall into one of three categories:
+
+1. Inline components
+2. Space-filling block components
+3. Grid-aware components
+
+### Inline components
+
+Inline components are the lowest level of components, and they should not be
+concerned with positioning or layout. These will often be the smallest level of
+component, some even containing only a single HTML element. For the most part,
+their size should be determined by their inner content, and they should not fill
+the space of their parent, but in certain cases, it may be useful to set a fixed
+size.
+
+Examples of inline components include buttons, input elements, title text, and
+paragraph text.
+
+### Space-filling block components
+
+Block components are the middle layer of components, and they represent
+compositions of inline components or other block components in order to form a
+cohesive unit. While a block component may control the layout of its child
+components, the block component itself should not control its own layout.
+Instead, it should expect that its parent sets properties such as sizing and
+margins and that it itself should expand to fill the available space.
+
+For example, block components generally should not be setting `height`, `width`,
+`margin` or `position` properties. Block components also should not be aligning
+themselves to any global grid layout.
+
+Example of block components include cards, carousels, and other recurring
+compositions of text and inline components.
+
+### Grid-aware components
+
+Grid-aware components are at the highest layer of the application, and in
+general are direct descendants of the top-level page. Grid-aware components
+should set up the grid tracks and place block-level components along the grid.
+These are the only components that should be aware of the global grid, and these
+components should mostly be concerned with positioning and not any other other
+styling information such as color or fonts.
+
+Examples of grid-aware components are the header and footer, hero banners, and
+any rectangular section of a page that spans the whole width of the page.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,86 @@
+# Getting Started
+
+This guide will walk through the steps for getting the application up and
+running for local development. There are two development web servers that we
+will use during development:
+
+1. [Gatsby](https://www.gatsbyjs.com/), a static website generator, and
+2. [Storybook](https://storybook.js.org/), a UI component tool.
+
+The Gatsby development server will serve a copy of the full website, while
+Storybook will present the individual UI components used on the site.
+
+
+## Requirements
+
+- Docker Desktop -
+  Follow the [Docker installation instructions](https://www.docker.com/get-started) for your operting system.
+- Git -
+  If you do not already have Git installed, please follow the [Git download instructions](https://git-scm.com/downloads) for your operating system.
+
+
+## Installing dependencies
+
+First, clone this repository with Git:
+
+```sh
+$ git clone git@github.com:ShelterTechSF/sheltertech.org.git
+```
+
+Then, in the newly created sheltertech.org directory, install the Node.js
+dependencies using Docker:
+
+```sh
+$ cd sheltertech.org
+$ docker-compose run --rm app npm install
+```
+
+
+## Running the Gatsby development server
+
+To start the Gatsby development server, run:
+
+```sh
+$ docker-compose up app
+```
+
+This will start the development web server at http://localhost:8000. The
+development server will automatically refresh your browser when any source file
+is modified.
+
+To stop the development server, you can simply send an interrupt signal to the
+`docker-compose up app` command by pressing Control + C.
+
+
+## Running the Storybook server
+
+[Storybook](https://storybook.js.org/) is a tool for developing reusable UI
+components. When developing a new component, it is recommended to develop it in
+Storybook first, since this encourages building it as a modular, isolated
+component before including it in the Gatsby-based site.
+
+```sh
+$ docker-compose up storybook
+```
+
+This will start the development web server at http://localhost:6006. The
+development server will automatically refresh your browser when any source file
+is modified.
+
+To stop the server, you can simply send an interrupt signal to the
+`docker-compose up storybook` command by pressing Control + C.
+
+
+## Running lint checks
+
+We strictly enforce code style using lint checks that run every time a pull
+request is submitted on GitHub. You should run the lint checks frequently while
+you are developing on the site so that you catch and fix lint issues before
+submitting a pull request.
+
+To run the lint checks and automatically fix any issues that can be
+automatically fixed, run:
+
+```sh
+$ docker-compose run --rm app npm run lint:fix
+```

--- a/docs/how-to-deploy.md
+++ b/docs/how-to-deploy.md
@@ -1,0 +1,21 @@
+# How To Deploy
+
+sheltertech.org has two deployment environments: staging.sheltertech.org and
+www.sheltertech.org. Both are hosted on [AWS S3](https://aws.amazon.com/s3/)
+buckets, and the deployments are both done via
+[GitHub Actions](https://docs.github.com/en/actions).
+
+Staging deployments are automatically triggered when a pull request is merged
+into the `main` branch.
+
+Production deployments must be manually triggered from the GitHub web interface.
+To deploy, click on the
+[Actions](https://github.com/ShelterTechSF/sheltertech.org/actions) tab from any
+GitHub page within the sheltertech.org repository, and then click on the
+[Deploy Production](https://github.com/ShelterTechSF/sheltertech.org/actions?query=workflow%3A%22Deploy+Production%22)
+workflow on the left side bar. Then click the **Run workflow** button on the
+right side, select the `main` branch, and then click the green **Run workflow**
+button. After the workflow finishes running, you should see the updated site at
+www.sheltertech.org.
+
+![Deploy Production](./deploy-production.png)


### PR DESCRIPTION
I did some reorganization of the docs so that they are now split up into separate files, rather than all living in the main README. We now have the four documents:

- A getting started guide, which is a bit more detailed than what was previously in the README
- A command-line quick reference, which contains lists of common commands to run when developing the app
- A how to deploy guide, which describes how to deploy to production
- A new guide I'm calling the Component Design System, which describes the three levels of components that I think we should build our components around. This is how I am hoping we will organize the components in the repository directory structure as well as in Storybook.