### PR TITLE
stylelint: Change selector class pattern to match camelCase rules.

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "stylelint-config-sass-guidelines"
+  "extends": "stylelint-config-sass-guidelines",
+  "rules": {
+    "selector-class-pattern": "[a-z][0-9A-Za-z]*"
+  }
 }


### PR DESCRIPTION
This PR changes the stylelint rules such that CSS class names are expected to be written in camelCase. Previously, it expected kebab-case class names, which is what I normally prefer, but because we are using CSS modules, I think it's more convenient to use camelCase because we can then access the class names using dot notation instead of bracket notation in JavaScript.

I hit this while I was working on one of the components myself, and I saw that @cw323 had hit it in https://github.com/ShelterTechSF/sheltertech.org/pull/61 as well.