### PR TITLE
Disable padding in Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -30,4 +30,6 @@ window.___navigate = (pathname) => {
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
+  // If this is left to its default value of 'padded', then it interferes with the mobile views.
+  layout: "fullscreen",
 };


### PR DESCRIPTION
I was hitting this issue when working on https://github.com/ShelterTechSF/sheltertech.org/pull/66, where when I activated the smaller viewports, such as mobile and tablet, the padding in the viewport area of Storybook was getting in the way.

This changes the `layout` configuration parameter for Storybook from `padded` to `fullscreen`, which gets rid of the padding. https://storybook.js.org/docs/react/configure/story-layout