### PR TITLE
Scope legacy global styles

### DIFF
--- a/src/legacy/components/pages/annual-report-2018/AnnualReportView.scss
+++ b/src/legacy/components/pages/annual-report-2018/AnnualReportView.scss
@@ -1,453 +1,461 @@
 @import '../../../stylesheets/utils/all';
 
-.annual-report {
-  align-items: center;
-  display: flex;
-  flex: 0 0 auto;
-  flex-direction: column;
-  justify-content: space-between;
-}
+// Disable this because we need to temporarily add extra specificity to all
+// legacy styles in the middle of the site transition. All the legacy styles and
+// code will go away soon.
+/* stylelint-disable max-nesting-depth */
+/* stylelint-disable selector-max-compound-selectors */
 
-.annual-report h2 {
-  color: $color-black;
-  font-size: calc-em(3.2 * 15px);
-  font-weight: 700;
-  line-height: 1.2;
-  max-width: 800px;
-  @media screen and (max-width: 600px) {
-    font-size: calc-em(2.4 * 15px);
-    line-height: 1.2;
-  }
-}
-
-.annual-report .blue {
-  color: $color-brand;
-}
-
-.annual-report--overview {
-  padding-bottom: 150px;
-  width: 100%;
-}
-
-.annual-report .wrapper {
-  flex-direction: column;
-  margin: 0 auto;
-  max-width: 1200px;
-  width: 90%;
-}
-
-.annual-report--year {
-  color: $color-brand;
-  font-size: 12vw;
-  @media screen and (min-width: 1400px) {
-    font-size: calc-em(12 * 15px);
-  }
-  @media screen and (max-width: 500px) {
-    font-size: calc-em(6 * 15px);
-    line-height: 1.2;
-  }
-}
-
-.annual-report--hero {
-  color: $color-black;
-  font-size: 6vw;
-  letter-spacing: -2px;
-  line-height: 6.875vw;
-  margin-bottom: 50px;
-  max-width: 620px;
-  width: 90%;
-  @media screen and (min-width: 1400px) {
-    font-size: calc-em(6 * 15px);
-    line-height: calc-em(6.875 * 15px);
-  }
-  @media screen and (max-width: 500px) {
-    font-size: calc-em(3 * 15px);
-    line-height: 1.2;
-  }
-}
-
-.annual-report--text {
-  font-size: 18px;
-  line-height: 26px;
-  max-width: 600px;
-  width: 100%;
-}
-
-.annual-report--growth {
-  background-image: url('./assets/team-growth.png');
-  background-position: bottom left;
-  background-repeat: no-repeat;
-  background-size: contain;
-  height: 0;
-  margin-top: 60px;
-  padding-bottom: 45%;
-  width: 100%;
-  @media screen and (max-width: 1000px) {
-    padding-bottom: 60%;
-  }
-  @media screen and (max-width: 500px) {
-    padding-bottom: 80%;
-  }
-}
-
-.annual-report--goals {
-  margin-top: 100px;
-  max-width: 950px;
-
-  ul {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    margin-top: 60px;
-  }
-}
-
-.annual-report--goals ul {
-  li {
+.app {
+  .annual-report {
     align-items: center;
-    border-top: 1px solid $color-brand;
     display: flex;
-    height: 130px;
-    padding: 0 50px;
-    position: relative;
-    width: 45%;
-    @media screen and (max-width: 600px) {
-      height: 100px;
-      padding: 10px 0 0 20px;
-    }
-  }
-}
-
-.annual-report--goals li {
-  &:nth-last-of-type(-n+2) {
-    border-bottom: 1px solid $color-brand;
+    flex: 0 0 auto;
+    flex-direction: column;
+    justify-content: space-between;
   }
 
-  > p {
-    font-size: calc-em(1.75 * 15px);
+  .annual-report h2 {
+    color: $color-black;
+    font-size: calc-em(3.2 * 15px);
     font-weight: 700;
+    line-height: 1.2;
+    max-width: 800px;
     @media screen and (max-width: 600px) {
-      font-size: calc-em(1.2 * 15px);
+      font-size: calc-em(2.4 * 15px);
       line-height: 1.2;
     }
   }
 
-  .goal-number {
+  .annual-report .blue {
     color: $color-brand;
-    font-size: calc-em(5.75 * 15px);
-    font-weight: 700;
-    left: 20px;
-    opacity: 0.3;
-    position: absolute;
-    top: 8px;
-    @media screen and (max-width: 600px) {
-      font-size: calc-em(4.5 * 15px);
-      left: 0;
-    }
-  }
-}
-
-.annual-report--shelterconnect {
-  background: $color-brand;
-  padding: 100px 0;
-  width: 100%;
-
-  img {
-    margin-bottom: 60px;
-    max-width: 400px;
-    width: 90%;
   }
 
-  h2 {
-    margin-top: 60px;
-  }
-
-  ul {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    margin-top: 60px;
-    width: 50%;
-    @media screen and (max-width: 600px) {
-      width: 100%;
-    }
-  }
-
-  p,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5 {
-    color: $color-white;
-  }
-}
-
-.annual-report--shelterconnect ul {
-  li {
-    border-top: 1px solid $color-white;
-    display: flex;
-    flex-direction: column;
-    height: 130px;
-    justify-content: center;
-    position: relative;
-    width: 45%;
-  }
-}
-
-.annual-report--shelterconnect li {
-  &:nth-last-of-type(-n+2) {
-    border-bottom: 1px solid $color-white;
-  }
-
-  .goal-number {
-    color: $color-white;
-    font-size: calc-em(3.5 * 15px);
-    @media screen and (max-width: 600px) {
-      font-size: calc-em(3 * 15px);
-    }
-  }
-
-  > p {
-    font-size: 13px;
-    line-height: 1.3;
-  }
-}
-
-.annual-report--askdarcel {
-  background-color: #276ce5;
-  background-image: url('./assets/askdarcel-bg.svg');
-  background-position: right bottom;
-  background-repeat: no-repeat;
-  background-size: contain;
-  padding: 100px 0;
-  width: 100%;
-
-  img {
-    margin-bottom: 60px;
-    max-width: 300px;
-    width: 90%;
-  }
-
-  p,
-  .white {
-    color: $color-white;
-  }
-
-  h2,
-  h3 {
-    color: rgba(255, 255, 255, 0.6);
-  }
-
-  h3 {
-    font-size: calc-em(2 * 15px);
-    font-weight: 700;
-    margin-top: 50px;
-    max-width: 700px;
-    @media screen and (max-width: 600px) {
-      font-size: calc-em(1.75 * 15px);
-    }
-  }
-}
-
-.annual-report--askdarcel-stats {
-  margin-top: 100px;
-
-  > p {
-    margin-top: 30px;
-  }
-
-  ul {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    margin-top: 20px;
-    width: 40%;
-    @media screen and (max-width: 600px) {
-      width: 100%;
-    }
-  }
-}
-
-.annual-report--askdarcel-stats ul {
-  li {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    margin-top: 20px;
-    position: relative;
-    width: 50%;
-  }
-}
-
-.annual-report--askdarcel-stats li {
-  .goal-number {
-    color: $color-white;
-    font-size: calc-em(2 * 15px);
-    font-weight: 700;
-  }
-
-  > p {
-    font-size: 13px;
-    line-height: 1.3;
-  }
-}
-
-.annual-report--casey {
-  background: #008fff;
-  padding: 100px 0;
-  width: 100%;
-  @media screen and (max-width: 600px) {
-    padding: 100px 0 50px;
-  }
-
-  img {
-    margin-bottom: 60px;
-    max-width: 330px;
-    width: 90%;
-  }
-
-  p,
-  h1,
-  h2,
-  h4,
-  h5,
-  .white {
-    color: $color-white;
-  }
-
-  h3 {
-    color: rgba(255, 255, 255, 0.6);
-    font-weight: 700;
-    max-width: 480px;
-  }
-
-  h4 {
-    font-weight: 700;
-    margin-top: 50px;
-  }
-
-  .mobile-hide {
-    @media screen and (max-width: 600px) {
-      display: none;
-    }
-  }
-}
-
-.annual-report--casey-stats {
-  margin-top: 50px;
-
-  > p {
-    margin-top: 30px;
-  }
-
-  ul {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    margin-top: 10px;
-    width: 70%;
-    @media screen and (max-width: 600px) {
-      width: 100%;
-    }
-  }
-
-  .casey-graph {
-    margin-top: 50px;
-    max-width: 1000px;
+  .annual-report--overview {
+    padding-bottom: 150px;
     width: 100%;
   }
-}
 
-.annual-report--casey-stats ul {
-  li {
-    border-bottom: 1px solid $color-white;
-    display: flex;
+  .annual-report .wrapper {
     flex-direction: column;
-    justify-content: center;
-    margin-top: 20px;
-    padding: 0 0 10px;
-    position: relative;
-    width: 28%;
+    margin: 0 auto;
+    max-width: 1200px;
+    width: 90%;
   }
-}
 
-.annual-report--casey-stats li {
-  .goal-number {
-    color: $color-white;
-    font-size: calc-em(2 * 15px);
-    font-weight: 700;
-    @media screen and (max-width: 600px) {
-      font-size: calc-em(1.75 * 15px);
+  .annual-report--year {
+    color: $color-brand;
+    font-size: 12vw;
+    @media screen and (min-width: 1400px) {
+      font-size: calc-em(12 * 15px);
+    }
+    @media screen and (max-width: 500px) {
+      font-size: calc-em(6 * 15px);
+      line-height: 1.2;
     }
   }
 
-  > p {
-    font-size: 13px;
-    line-height: 1.3;
-  }
-}
-
-.annual-report--2019 {
-  width: 100%;
-
-  h1 {
-    color: $color-brand;
+  .annual-report--hero {
+    color: $color-black;
     font-size: 6vw;
-    margin-top: 100px;
-    width: 50%;
+    letter-spacing: -2px;
+    line-height: 6.875vw;
+    margin-bottom: 50px;
+    max-width: 620px;
+    width: 90%;
     @media screen and (min-width: 1400px) {
       font-size: calc-em(6 * 15px);
+      line-height: calc-em(6.875 * 15px);
     }
     @media screen and (max-width: 500px) {
       font-size: calc-em(3 * 15px);
       line-height: 1.2;
-      width: 90%;
     }
   }
 
   .annual-report--text {
-    margin-top: 30px;
-  }
-}
-
-
-.annual-report--2019-goals {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  margin-top: 60px;
-  width: 80%;
-  @media screen and (max-width: 600px) {
+    font-size: 18px;
+    line-height: 26px;
+    max-width: 600px;
     width: 100%;
   }
 
-  li {
-    align-items: center;
-    border-top: 1px solid $color-brand;
-    display: flex;
-    height: 130px;
-    padding: 0 15% 0 0;
-    position: relative;
-    width: 45%;
-  }
-}
-
-.annual-report--2019-goals li {
-  @media screen and (max-width: 600px) {
-    padding: 10px 0;
-  }
-
-  &:nth-last-of-type(-n+2) {
-    border-bottom: 1px solid $color-brand;
+  .annual-report--growth {
+    background-image: url('./assets/team-growth.png');
+    background-position: bottom left;
+    background-repeat: no-repeat;
+    background-size: contain;
+    height: 0;
+    margin-top: 60px;
+    padding-bottom: 45%;
+    width: 100%;
+    @media screen and (max-width: 1000px) {
+      padding-bottom: 60%;
+    }
+    @media screen and (max-width: 500px) {
+      padding-bottom: 80%;
+    }
   }
 
-  > p {
-    color: $color-black;
-    font-size: calc-em(1.75 * 15px);
-    font-weight: 700;
+  .annual-report--goals {
+    margin-top: 100px;
+    max-width: 950px;
+
+    ul {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      margin-top: 60px;
+    }
+  }
+
+  .annual-report--goals ul {
+    li {
+      align-items: center;
+      border-top: 1px solid $color-brand;
+      display: flex;
+      height: 130px;
+      padding: 0 50px;
+      position: relative;
+      width: 45%;
+      @media screen and (max-width: 600px) {
+        height: 100px;
+        padding: 10px 0 0 20px;
+      }
+    }
+  }
+
+  .annual-report--goals li {
+    &:nth-last-of-type(-n+2) {
+      border-bottom: 1px solid $color-brand;
+    }
+
+    > p {
+      font-size: calc-em(1.75 * 15px);
+      font-weight: 700;
+      @media screen and (max-width: 600px) {
+        font-size: calc-em(1.2 * 15px);
+        line-height: 1.2;
+      }
+    }
+
+    .goal-number {
+      color: $color-brand;
+      font-size: calc-em(5.75 * 15px);
+      font-weight: 700;
+      left: 20px;
+      opacity: 0.3;
+      position: absolute;
+      top: 8px;
+      @media screen and (max-width: 600px) {
+        font-size: calc-em(4.5 * 15px);
+        left: 0;
+      }
+    }
+  }
+
+  .annual-report--shelterconnect {
+    background: $color-brand;
+    padding: 100px 0;
+    width: 100%;
+
+    img {
+      margin-bottom: 60px;
+      max-width: 400px;
+      width: 90%;
+    }
+
+    h2 {
+      margin-top: 60px;
+    }
+
+    ul {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      margin-top: 60px;
+      width: 50%;
+      @media screen and (max-width: 600px) {
+        width: 100%;
+      }
+    }
+
+    p,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5 {
+      color: $color-white;
+    }
+  }
+
+  .annual-report--shelterconnect ul {
+    li {
+      border-top: 1px solid $color-white;
+      display: flex;
+      flex-direction: column;
+      height: 130px;
+      justify-content: center;
+      position: relative;
+      width: 45%;
+    }
+  }
+
+  .annual-report--shelterconnect li {
+    &:nth-last-of-type(-n+2) {
+      border-bottom: 1px solid $color-white;
+    }
+
+    .goal-number {
+      color: $color-white;
+      font-size: calc-em(3.5 * 15px);
+      @media screen and (max-width: 600px) {
+        font-size: calc-em(3 * 15px);
+      }
+    }
+
+    > p {
+      font-size: 13px;
+      line-height: 1.3;
+    }
+  }
+
+  .annual-report--askdarcel {
+    background-color: #276ce5;
+    background-image: url('./assets/askdarcel-bg.svg');
+    background-position: right bottom;
+    background-repeat: no-repeat;
+    background-size: contain;
+    padding: 100px 0;
+    width: 100%;
+
+    img {
+      margin-bottom: 60px;
+      max-width: 300px;
+      width: 90%;
+    }
+
+    p,
+    .white {
+      color: $color-white;
+    }
+
+    h2,
+    h3 {
+      color: rgba(255, 255, 255, 0.6);
+    }
+
+    h3 {
+      font-size: calc-em(2 * 15px);
+      font-weight: 700;
+      margin-top: 50px;
+      max-width: 700px;
+      @media screen and (max-width: 600px) {
+        font-size: calc-em(1.75 * 15px);
+      }
+    }
+  }
+
+  .annual-report--askdarcel-stats {
+    margin-top: 100px;
+
+    > p {
+      margin-top: 30px;
+    }
+
+    ul {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      margin-top: 20px;
+      width: 40%;
+      @media screen and (max-width: 600px) {
+        width: 100%;
+      }
+    }
+  }
+
+  .annual-report--askdarcel-stats ul {
+    li {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      margin-top: 20px;
+      position: relative;
+      width: 50%;
+    }
+  }
+
+  .annual-report--askdarcel-stats li {
+    .goal-number {
+      color: $color-white;
+      font-size: calc-em(2 * 15px);
+      font-weight: 700;
+    }
+
+    > p {
+      font-size: 13px;
+      line-height: 1.3;
+    }
+  }
+
+  .annual-report--casey {
+    background: #008fff;
+    padding: 100px 0;
+    width: 100%;
     @media screen and (max-width: 600px) {
-      font-size: calc-em(1.2 * 15px);
+      padding: 100px 0 50px;
+    }
+
+    img {
+      margin-bottom: 60px;
+      max-width: 330px;
+      width: 90%;
+    }
+
+    p,
+    h1,
+    h2,
+    h4,
+    h5,
+    .white {
+      color: $color-white;
+    }
+
+    h3 {
+      color: rgba(255, 255, 255, 0.6);
+      font-weight: 700;
+      max-width: 480px;
+    }
+
+    h4 {
+      font-weight: 700;
+      margin-top: 50px;
+    }
+
+    .mobile-hide {
+      @media screen and (max-width: 600px) {
+        display: none;
+      }
+    }
+  }
+
+  .annual-report--casey-stats {
+    margin-top: 50px;
+
+    > p {
+      margin-top: 30px;
+    }
+
+    ul {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      margin-top: 10px;
+      width: 70%;
+      @media screen and (max-width: 600px) {
+        width: 100%;
+      }
+    }
+
+    .casey-graph {
+      margin-top: 50px;
+      max-width: 1000px;
+      width: 100%;
+    }
+  }
+
+  .annual-report--casey-stats ul {
+    li {
+      border-bottom: 1px solid $color-white;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      margin-top: 20px;
+      padding: 0 0 10px;
+      position: relative;
+      width: 28%;
+    }
+  }
+
+  .annual-report--casey-stats li {
+    .goal-number {
+      color: $color-white;
+      font-size: calc-em(2 * 15px);
+      font-weight: 700;
+      @media screen and (max-width: 600px) {
+        font-size: calc-em(1.75 * 15px);
+      }
+    }
+
+    > p {
+      font-size: 13px;
+      line-height: 1.3;
+    }
+  }
+
+  .annual-report--2019 {
+    width: 100%;
+
+    h1 {
+      color: $color-brand;
+      font-size: 6vw;
+      margin-top: 100px;
+      width: 50%;
+      @media screen and (min-width: 1400px) {
+        font-size: calc-em(6 * 15px);
+      }
+      @media screen and (max-width: 500px) {
+        font-size: calc-em(3 * 15px);
+        line-height: 1.2;
+        width: 90%;
+      }
+    }
+
+    .annual-report--text {
+      margin-top: 30px;
+    }
+  }
+
+
+  .annual-report--2019-goals {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-top: 60px;
+    width: 80%;
+    @media screen and (max-width: 600px) {
+      width: 100%;
+    }
+
+    li {
+      align-items: center;
+      border-top: 1px solid $color-brand;
+      display: flex;
+      height: 130px;
+      padding: 0 15% 0 0;
+      position: relative;
+      width: 45%;
+    }
+  }
+
+  .annual-report--2019-goals li {
+    @media screen and (max-width: 600px) {
+      padding: 10px 0;
+    }
+
+    &:nth-last-of-type(-n+2) {
+      border-bottom: 1px solid $color-brand;
+    }
+
+    > p {
+      color: $color-black;
+      font-size: calc-em(1.75 * 15px);
+      font-weight: 700;
+      @media screen and (max-width: 600px) {
+        font-size: calc-em(1.2 * 15px);
+      }
     }
   }
 }

--- a/src/legacy/components/pages/annual-report-2018/AnnualReportView.scss
+++ b/src/legacy/components/pages/annual-report-2018/AnnualReportView.scss
@@ -10,12 +10,12 @@
 
 .annual-report h2 {
   color: $color-black;
-  font-size: 3.2rem;
+  font-size: calc-em(3.2 * 15px);
   font-weight: 700;
   line-height: 1.2;
   max-width: 800px;
   @media screen and (max-width: 600px) {
-    font-size: 2.4rem;
+    font-size: calc-em(2.4 * 15px);
     line-height: 1.2;
   }
 }
@@ -40,10 +40,10 @@
   color: $color-brand;
   font-size: 12vw;
   @media screen and (min-width: 1400px) {
-    font-size: 12rem;
+    font-size: calc-em(12 * 15px);
   }
   @media screen and (max-width: 500px) {
-    font-size: 6rem;
+    font-size: calc-em(6 * 15px);
     line-height: 1.2;
   }
 }
@@ -57,11 +57,11 @@
   max-width: 620px;
   width: 90%;
   @media screen and (min-width: 1400px) {
-    font-size: 6rem;
-    line-height: 6.875rem;
+    font-size: calc-em(6 * 15px);
+    line-height: calc-em(6.875 * 15px);
   }
   @media screen and (max-width: 500px) {
-    font-size: 3rem;
+    font-size: calc-em(3 * 15px);
     line-height: 1.2;
   }
 }
@@ -124,24 +124,24 @@
   }
 
   > p {
-    font-size: 1.75rem;
+    font-size: calc-em(1.75 * 15px);
     font-weight: 700;
     @media screen and (max-width: 600px) {
-      font-size: 1.2rem;
+      font-size: calc-em(1.2 * 15px);
       line-height: 1.2;
     }
   }
 
   .goal-number {
     color: $color-brand;
-    font-size: 5.75rem;
+    font-size: calc-em(5.75 * 15px);
     font-weight: 700;
     left: 20px;
     opacity: 0.3;
     position: absolute;
     top: 8px;
     @media screen and (max-width: 600px) {
-      font-size: 4.5rem;
+      font-size: calc-em(4.5 * 15px);
       left: 0;
     }
   }
@@ -202,9 +202,9 @@
 
   .goal-number {
     color: $color-white;
-    font-size: 3.5rem;
+    font-size: calc-em(3.5 * 15px);
     @media screen and (max-width: 600px) {
-      font-size: 3rem;
+      font-size: calc-em(3 * 15px);
     }
   }
 
@@ -240,12 +240,12 @@
   }
 
   h3 {
-    font-size: 2rem;
+    font-size: calc-em(2 * 15px);
     font-weight: 700;
     margin-top: 50px;
     max-width: 700px;
     @media screen and (max-width: 600px) {
-      font-size: 1.75rem;
+      font-size: calc-em(1.75 * 15px);
     }
   }
 }
@@ -283,7 +283,7 @@
 .annual-report--askdarcel-stats li {
   .goal-number {
     color: $color-white;
-    font-size: 2rem;
+    font-size: calc-em(2 * 15px);
     font-weight: 700;
   }
 
@@ -375,10 +375,10 @@
 .annual-report--casey-stats li {
   .goal-number {
     color: $color-white;
-    font-size: 2rem;
+    font-size: calc-em(2 * 15px);
     font-weight: 700;
     @media screen and (max-width: 600px) {
-      font-size: 1.75rem;
+      font-size: calc-em(1.75 * 15px);
     }
   }
 
@@ -397,10 +397,10 @@
     margin-top: 100px;
     width: 50%;
     @media screen and (min-width: 1400px) {
-      font-size: 6rem;
+      font-size: calc-em(6 * 15px);
     }
     @media screen and (max-width: 500px) {
-      font-size: 3rem;
+      font-size: calc-em(3 * 15px);
       line-height: 1.2;
       width: 90%;
     }
@@ -444,10 +444,10 @@
 
   > p {
     color: $color-black;
-    font-size: 1.75rem;
+    font-size: calc-em(1.75 * 15px);
     font-weight: 700;
     @media screen and (max-width: 600px) {
-      font-size: 1.2rem;
+      font-size: calc-em(1.2 * 15px);
     }
   }
 }

--- a/src/legacy/components/pages/donate/DonateView.scss
+++ b/src/legacy/components/pages/donate/DonateView.scss
@@ -1,89 +1,96 @@
 @import '../../../stylesheets/utils/all';
 
-.donate-form-button {
-  height: 44px;
-  margin-top: 25px;
-  width: 190px;
+// Disable this because we need to temporarily add extra specificity to all
+// legacy styles in the middle of the site transition. All the legacy styles and
+// code will go away soon.
+/* stylelint-disable max-nesting-depth */
 
-  &:hover {
-    position: relative;
-    top: 1px;
+.app {
+  .donate-form-button {
+    height: 44px;
+    margin-top: 25px;
+    width: 190px;
+
+    &:hover {
+      position: relative;
+      top: 1px;
+    }
   }
-}
 
-.donate--cards {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-evenly;
-  margin-top: 60px;
-  max-width: 1050px;
-  width: 80vw;
-  @include r_max($screen-sm) {
-    align-items: stretch;
+  .donate--cards {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
+    margin-top: 60px;
+    max-width: 1050px;
+    width: 80vw;
+    @include r_max($screen-sm) {
+      align-items: stretch;
+      flex-direction: column;
+      justify-content: center;
+    }
+  }
+
+  .donate--card {
+    align-items: center;
+    background-color: #fff;
+    border: 1px solid #cfcfcf;
+    border-radius: 9px;
+    display: flex;
     flex-direction: column;
+    flex-grow: 1;
+    flex-shrink: 1;
     justify-content: center;
-  }
-}
-
-.donate--card {
-  align-items: center;
-  background-color: #fff;
-  border: 1px solid #cfcfcf;
-  border-radius: 9px;
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  flex-shrink: 1;
-  justify-content: center;
-  margin: 15px;
-  padding: 25px 25px 40px;
-  text-align: center;
-  @include r_max($screen-md) {
     margin: 15px;
-    padding: 20px;
+    padding: 25px 25px 40px;
+    text-align: center;
+    @include r_max($screen-md) {
+      margin: 15px;
+      padding: 20px;
+    }
   }
-}
-
-.donate--card--amount {
-  color: $color-brand;
-  font-size: 72px;
-  line-height: 1;
-  margin: 0;
-}
-
-.donate--card h6 {
-  color: $color-brand;
-  font-size: 16px;
-  font-weight: 500;
-  margin-top: 15px;
-  text-transform: uppercase;
-}
-
-.donate--card p {
-  margin-top: 15px;
-  max-width: 260px;
-}
-
-.donate--card--custom {
-  flex-grow: 2;
 
   .donate--card--amount {
-    font-size: 36px;
-    margin-bottom: 20px;
-    width: 100%;
+    color: $color-brand;
+    font-size: 72px;
+    line-height: 1;
+    margin: 0;
   }
 
-  p {
-    max-width: 600px;
+  .donate--card h6 {
+    color: $color-brand;
+    font-size: 16px;
+    font-weight: 500;
+    margin-top: 15px;
+    text-transform: uppercase;
   }
-}
 
-.donate--legal {
-  margin: 60px 0 0;
-  max-width: 580px;
-  width: 70vw;
-}
+  .donate--card p {
+    margin-top: 15px;
+    max-width: 260px;
+  }
 
-.donate--address {
-  text-align: right;
+  .donate--card--custom {
+    flex-grow: 2;
+
+    .donate--card--amount {
+      font-size: 36px;
+      margin-bottom: 20px;
+      width: 100%;
+    }
+
+    p {
+      max-width: 600px;
+    }
+  }
+
+  .donate--legal {
+    margin: 60px 0 0;
+    max-width: 580px;
+    width: 70vw;
+  }
+
+  .donate--address {
+    text-align: right;
+  }
 }

--- a/src/legacy/components/pages/events/EventsList.scss
+++ b/src/legacy/components/pages/events/EventsList.scss
@@ -1,90 +1,99 @@
-.events-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  margin-top: 60px;
-  width: 90vw;
-}
+@import '../../../stylesheets/utils/all';
 
-.events-list-item {
-  margin: 10px;
-  position: relative;
-  width: 320px;
-}
+// Disable this because we need to temporarily add extra specificity to all
+// legacy styles in the middle of the site transition. All the legacy styles and
+// code will go away soon.
+/* stylelint-disable max-nesting-depth */
 
-/* Unset styles applied globally to the <a> tag that do not make sense when the
+.app {
+  .events-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 60px;
+    width: 90vw;
+  }
+
+  .events-list-item {
+    margin: 10px;
+    position: relative;
+    width: 320px;
+  }
+
+  /* Unset styles applied globally to the <a> tag that do not make sense when the
  * <a> tag wraps other elements and not just text.
  */
-.event-card-link {
-  color: inherit;
+  .event-card-link {
+    color: inherit;
 
-  &:hover {
-    position: initial;
-    top: initial;
+    &:hover {
+      position: initial;
+      top: initial;
+    }
   }
-}
 
-.event-card {
-  background-color: #fff;
-  border: 1px solid #cfcfcf;
-  border-radius: 9px;
-  cursor: pointer;
-  display: flex;
-  flex: 0 0 auto;
-  flex-direction: column;
-  height: 100%;
-  overflow: hidden;
-}
+  .event-card {
+    background-color: #fff;
+    border: 1px solid #cfcfcf;
+    border-radius: 9px;
+    cursor: pointer;
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+  }
 
-.event-card--cost {
-  background: transparentize($color: #fff, $amount: 0.2);
-  color: #151515;
-  font-size: 13px;
-  line-height: 18px;
-  padding: 5px 12px;
-  position: absolute;
-  right: 20px;
-  text-align: center;
-  text-transform: uppercase;
-  top: 17px;
-}
+  .event-card--cost {
+    background: transparentize($color: #fff, $amount: 0.2);
+    color: #151515;
+    font-size: 13px;
+    line-height: 18px;
+    padding: 5px 12px;
+    position: absolute;
+    right: 20px;
+    text-align: center;
+    text-transform: uppercase;
+    top: 17px;
+  }
 
-.event-card--image {
-  height: 200px;
-  width: 400px;
-}
+  .event-card--image {
+    height: 200px;
+    width: 400px;
+  }
 
-.event-card--details {
-  display: flex;
-  flex: 1 0 auto;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: 20px 25px;
-}
+  .event-card--details {
+    display: flex;
+    flex: 1 0 auto;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 20px 25px;
+  }
 
-.event-card--details--date {
-  color: #484848;
-  font-size: 15px;
-  text-transform: uppercase;
-}
+  .event-card--details--date {
+    color: #484848;
+    font-size: 15px;
+    text-transform: uppercase;
+  }
 
-.event-card h4 {
-  color: #1d1d1d;
-  font-weight: bold;
-  margin-top: 8px;
-}
+  .event-card h4 {
+    color: #1d1d1d;
+    font-weight: bold;
+    margin-top: 8px;
+  }
 
-.event-card--details--description {
-  margin-top: 15px;
-}
+  .event-card--details--description {
+    margin-top: 15px;
+  }
 
-.event-card--details small {
-  display: block;
-  margin-top: 30px;
-}
+  .event-card--details small {
+    display: block;
+    margin-top: 30px;
+  }
 
-.events--past {
-  font-style: italic;
-  font-weight: 300;
-  margin-top: 60px;
+  .events--past {
+    font-style: italic;
+    font-weight: 300;
+    margin-top: 60px;
+  }
 }

--- a/src/legacy/components/pages/get-involved/PositionsList.scss
+++ b/src/legacy/components/pages/get-involved/PositionsList.scss
@@ -1,71 +1,80 @@
-.positions h3 {
-  color: #484848;
-  font-weight: bold;
-  margin-top: 80px;
-}
+@import '../../../stylesheets/utils/all';
 
-.positions-list {
-  display: table;
-  flex-direction: column;
-  max-width: 910px;
-  width: 90vw;
-}
+// Disable this because we need to temporarily add extra specificity to all
+// legacy styles in the middle of the site transition. All the legacy styles and
+// code will go away soon.
+/* stylelint-disable max-nesting-depth */
 
-.positions-list--legend {
-  display: table-header-group;
-}
+.app {
+  .positions h3 {
+    color: #484848;
+    font-weight: bold;
+    margin-top: 80px;
+  }
 
-.positions-list--legend p {
-  color: #666;
-  display: table-cell;
-  font-size: 13px;
-  padding: 40px 0 30px;
+  .positions-list {
+    display: table;
+    flex-direction: column;
+    max-width: 910px;
+    width: 90vw;
+  }
 
-  &:first-of-type {
+  .positions-list--legend {
+    display: table-header-group;
+  }
+
+  .positions-list--legend p {
+    color: #666;
+    display: table-cell;
+    font-size: 13px;
+    padding: 40px 0 30px;
+
+    &:first-of-type {
+      width: 33%;
+    }
+  }
+
+  .positions-list--item {
+
+    display: table-row;
+    justify-content: flex-start;
+    margin: 0;
+    width: 100%;
+
+  }
+
+  .positions-list--item--title {
+    border-top: 1px solid #d8d8d8;
+    color: #0025e4;
+    display: table-cell;
+    flex: 0 1 auto;
+    font-size: 21px;
+    font-weight: bold;
+    padding: 40px 30px 35px 0;
     width: 33%;
+
+    &:hover {
+      top: 0;
+    }
   }
-}
 
-.positions-list--item {
+  .positions-list--item--desc {
+    border-top: 1px solid #d8d8d8;
+    color: #666;
+    display: table-cell;
+    flex: 2 1 auto;
+    font-size: 15px;
+    padding: 40px 0 35px;
+    width: 67%;
 
-  display: table-row;
-  justify-content: flex-start;
-  margin: 0;
-  width: 100%;
-
-}
-
-.positions-list--item--title {
-  border-top: 1px solid #d8d8d8;
-  color: #0025e4;
-  display: table-cell;
-  flex: 0 1 auto;
-  font-size: 21px;
-  font-weight: bold;
-  padding: 40px 30px 35px 0;
-  width: 33%;
-
-  &:hover {
-    top: 0;
+    &:hover {
+      top: 0;
+    }
   }
-}
 
-.positions-list--item--desc {
-  border-top: 1px solid #d8d8d8;
-  color: #666;
-  display: table-cell;
-  flex: 2 1 auto;
-  font-size: 15px;
-  padding: 40px 0 35px;
-  width: 67%;
-
-  &:hover {
-    top: 0;
+  .volunteer--contact {
+    margin-top: 40px;
+    max-width: 550px;
+    width: 90vw;
   }
-}
-
-.volunteer--contact {
-  margin-top: 40px;
-  max-width: 550px;
-  width: 90vw;
 }

--- a/src/legacy/components/pages/givingtuesday/GivingTuesdayView.scss
+++ b/src/legacy/components/pages/givingtuesday/GivingTuesdayView.scss
@@ -1,56 +1,66 @@
-.wrapper {
-  display: flex;
-  max-width: 1200px;
-  width: 95%;
-  @media screen and (max-width: 860px) {
-    flex-direction: column;
-    width: 90%;
+@import '../../../stylesheets/utils/all';
+
+// Disable this because we need to temporarily add extra specificity to all
+// legacy styles in the middle of the site transition. All the legacy styles and
+// code will go away soon.
+/* stylelint-disable max-nesting-depth */
+/* stylelint-disable selector-max-compound-selectors */
+
+.app {
+  .wrapper {
+    display: flex;
+    max-width: 1200px;
+    width: 95%;
+    @media screen and (max-width: 860px) {
+      flex-direction: column;
+      width: 90%;
+    }
   }
-}
 
-.content-left {
-  flex: 1 1 auto;
-  margin-right: 20px;
-}
+  .content-left {
+    flex: 1 1 auto;
+    margin-right: 20px;
+  }
 
-.content-left h2 {
-  color: #000;
-  font-size: 28px;
-  font-weight: 300;
-  margin: 30px 0 15px;
-  max-width: 600px;
-}
+  .content-left h2 {
+    color: #000;
+    font-size: 28px;
+    font-weight: 300;
+    margin: 30px 0 15px;
+    max-width: 600px;
+  }
 
-.content-left p {
-  font-size: 15px;
-  line-height: 130%;
-  margin: 0 0 15px;
-  max-width: 600px;
-}
+  .content-left p {
+    font-size: 15px;
+    line-height: 130%;
+    margin: 0 0 15px;
+    max-width: 600px;
+  }
 
-.content-left ul {
-  list-style-position: inside;
-  list-style-type: disc;
-  margin-bottom: 15px;
-}
+  .content-left ul {
+    list-style-position: inside;
+    list-style-type: disc;
+    margin-bottom: 15px;
+  }
 
-.content-left ul li {
-  margin-bottom: 10px;
-}
+  .content-left ul li {
+    margin-bottom: 10px;
+  }
 
-/* Not worth fixing this for legacy page */
-/* stylelint-disable selector-class-pattern */
-.GivingTuesday--photo {
-  height: auto;
-  max-width: 600px;
-  width: 100%;
-}
+  /* Not worth fixing this for legacy page */
+  /* stylelint-disable selector-class-pattern */
+  .GivingTuesday--photo {
+    height: auto;
+    max-width: 600px;
+    width: 100%;
+  }
 
-.content-right {
-  flex: 0 0 460px;
-}
+  .content-right {
+    flex: 0 0 460px;
+  }
 
-.giveLivelyEmbed {
-  height: 100%;
-  min-height: 1800px;
+  .giveLivelyEmbed {
+    height: 100%;
+    min-height: 1800px;
+  }
 }

--- a/src/legacy/components/pages/team/TeamView.scss
+++ b/src/legacy/components/pages/team/TeamView.scss
@@ -1,271 +1,280 @@
-.team {
-  align-items: center;
-  display: flex;
-  flex: 0 0 auto;
-  flex-direction: column;
-  justify-content: space-between;
-}
+@import '../../../stylesheets/utils/all';
 
-.team-list {
-  display: flex;
-  flex-wrap: wrap;
-  margin-top: 60px;
-  max-width: 910px;
-  width: 90vw;
-}
+// Disable this because we need to temporarily add extra specificity to all
+// legacy styles in the middle of the site transition. All the legacy styles and
+// code will go away soon.
+/* stylelint-disable max-nesting-depth */
 
-.team-list-header {
-  color: #484848;
-  margin-bottom: 20px;
-  width: 100%;
-}
-
-.team-list--item {
-  background-color: #f9f9f9;
-  background-position: center;
-  background-size: cover;
-  height: 0;
-  margin: 2px;
-  padding-bottom: 19%;
-  position: relative;
-  width: 19%;
-  @media screen and (max-width:800px) {
-    padding-bottom: 32%;
-    width: 32%;
+.app {
+  .team {
+    align-items: center;
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    justify-content: space-between;
   }
-  @media screen and (max-width:450px) {
-    padding-bottom: 48%;
-    width: 48%;
+
+  .team-list {
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: 60px;
+    max-width: 910px;
+    width: 90vw;
   }
-}
 
-.team-list--item--details {
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.65) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-  bottom: 0;
-  color: #fff;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#a6000000', GradientType=0);
-  left: 0;
-  padding: 10px;
-  position: absolute;
-  text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
-  width: 100%;
-
-  p {
-    margin-bottom: 0;
+  .team-list-header {
+    color: #484848;
+    margin-bottom: 20px;
+    width: 100%;
   }
-}
 
-.team-list--item--name {
-  font-size: 15px;
-  font-weight: 600;
-}
+  .team-list--item {
+    background-color: #f9f9f9;
+    background-position: center;
+    background-size: cover;
+    height: 0;
+    margin: 2px;
+    padding-bottom: 19%;
+    position: relative;
+    width: 19%;
+    @media screen and (max-width:800px) {
+      padding-bottom: 32%;
+      width: 32%;
+    }
+    @media screen and (max-width:450px) {
+      padding-bottom: 48%;
+      width: 48%;
+    }
+  }
 
-.team-list--item--title {
-  font-size: 12px;
-}
+  .team-list--item--details {
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.65) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+    bottom: 0;
+    color: #fff;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#a6000000', GradientType=0);
+    left: 0;
+    padding: 10px;
+    position: absolute;
+    text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
+    width: 100%;
 
-.team-list--item--details a {
-  color: #fff;
-}
+    p {
+      margin-bottom: 0;
+    }
+  }
 
-// PHOTOS //
+  .team-list--item--name {
+    font-size: 15px;
+    font-weight: 600;
+  }
 
-.team-list--item.placeholder {
-  background-image: url('assets/placeholder.png');
-}
+  .team-list--item--title {
+    font-size: 12px;
+  }
 
-.team-list--item.darcel {
-  background-image: url('assets/darcel-headshot.jpg');
-}
+  .team-list--item--details a {
+    color: #fff;
+  }
 
-.team-list--item.hicham {
-  background-image: url('assets/hicham-press.jpg');
-}
+  // PHOTOS //
 
-.team-list--item.derek {
-  background-image: url('assets/derek-fidler.jpg');
-}
+  .team-list--item.placeholder {
+    background-image: url('assets/placeholder.png');
+  }
 
-.team-list--item.joe {
-  background-image: url('assets/joeFreund.jpg');
-}
+  .team-list--item.darcel {
+    background-image: url('assets/darcel-headshot.jpg');
+  }
 
-.team-list--item.phil {
-  background-image: url('assets/phil-chu.jpg');
-}
+  .team-list--item.hicham {
+    background-image: url('assets/hicham-press.jpg');
+  }
 
-.team-list--item.richard {
-  background-image: url('assets/Richard-Xia.jpg');
-}
+  .team-list--item.derek {
+    background-image: url('assets/derek-fidler.jpg');
+  }
 
-.team-list--item.molly-c {
-  background-image: url('assets/molly-cohen.jpg');
-}
+  .team-list--item.joe {
+    background-image: url('assets/joeFreund.jpg');
+  }
 
-.team-list--item.glasha {
-  background-image: url('assets/glasha-marcon.jpg');
-}
+  .team-list--item.phil {
+    background-image: url('assets/phil-chu.jpg');
+  }
 
-.team-list--item.leland {
-  background-image: url('assets/lelandGarofalo.jpg');
-}
+  .team-list--item.richard {
+    background-image: url('assets/Richard-Xia.jpg');
+  }
 
-.team-list--item.scott {
-  background-image: url('assets/scott-nelson.png');
-}
+  .team-list--item.molly-c {
+    background-image: url('assets/molly-cohen.jpg');
+  }
 
-.team-list--item.aaron {
-  background-image: url('assets/aaron-mendez.png');
-}
+  .team-list--item.glasha {
+    background-image: url('assets/glasha-marcon.jpg');
+  }
 
-.team-list--item.marilyn {
-  background-image: url('assets/marilyn-chan.png');
-}
+  .team-list--item.leland {
+    background-image: url('assets/lelandGarofalo.jpg');
+  }
 
-.team-list--item.thomas {
-  background-image: url('assets/thomas-wolfe.jpg');
-}
+  .team-list--item.scott {
+    background-image: url('assets/scott-nelson.png');
+  }
 
-.team-list--item.alex-h {
-  background-image: url('assets/alex-holden.jpg');
-}
+  .team-list--item.aaron {
+    background-image: url('assets/aaron-mendez.png');
+  }
 
-.team-list--item.alexander {
-  background-image: url('assets/alexander-turinske.jpg');
-}
+  .team-list--item.marilyn {
+    background-image: url('assets/marilyn-chan.png');
+  }
 
-.team-list--item.eric {
-  background-image: url('assets/eric-petzel.jpg');
-}
+  .team-list--item.thomas {
+    background-image: url('assets/thomas-wolfe.jpg');
+  }
 
-.team-list--item.rashmi {
-  background-image: url('assets/rashmi-balekundargir.jpg');
-}
+  .team-list--item.alex-h {
+    background-image: url('assets/alex-holden.jpg');
+  }
 
-.team-list--item.zana {
-  background-image: url('assets/zana-jipsen.jpg');
-}
+  .team-list--item.alexander {
+    background-image: url('assets/alexander-turinske.jpg');
+  }
 
-.team-list--item.truc {
-  background-image: url('assets/truc-nguyen.jpg');
-}
+  .team-list--item.eric {
+    background-image: url('assets/eric-petzel.jpg');
+  }
 
-.team-list--item.vlad {
-  background-image: url('assets/vlad-metrik.jpg');
-}
+  .team-list--item.rashmi {
+    background-image: url('assets/rashmi-balekundargir.jpg');
+  }
 
-.team-list--item.sharanya {
-  background-image: url('assets/sharanya-venkat.png');
-}
+  .team-list--item.zana {
+    background-image: url('assets/zana-jipsen.jpg');
+  }
 
-.team-list--item.jasmine {
-  background-image: url('assets/jasmine-cheng.jpg');
-}
+  .team-list--item.truc {
+    background-image: url('assets/truc-nguyen.jpg');
+  }
 
-.team-list--item.ruochen {
-  background-image: url('assets/ruochen-huang.jpg');
-}
+  .team-list--item.vlad {
+    background-image: url('assets/vlad-metrik.jpg');
+  }
 
-.team-list--item.max {
-  background-image: url('assets/max-stuart.png');
-}
+  .team-list--item.sharanya {
+    background-image: url('assets/sharanya-venkat.png');
+  }
 
-.team-list--item.jr {
-  background-image: url('assets/jr-formanek.png');
-}
+  .team-list--item.jasmine {
+    background-image: url('assets/jasmine-cheng.jpg');
+  }
 
-.team-list--item.anna {
-  background-image: url('assets/anna-kalkanis.png');
-}
+  .team-list--item.ruochen {
+    background-image: url('assets/ruochen-huang.jpg');
+  }
 
-.team-list--item.brian {
-  background-image: url('assets/brian-schroer.jpg');
-}
+  .team-list--item.max {
+    background-image: url('assets/max-stuart.png');
+  }
 
-.team-list--item.avneet {
-  background-image: url('assets/avneet-chadha.jpg');
-}
+  .team-list--item.jr {
+    background-image: url('assets/jr-formanek.png');
+  }
 
-.team-list--item.cliff {
-  background-image: url('assets/cliff-crosland.png');
-}
+  .team-list--item.anna {
+    background-image: url('assets/anna-kalkanis.png');
+  }
 
-.team-list--item.michelle {
-  background-image: url('assets/michelle-carey.png');
-}
+  .team-list--item.brian {
+    background-image: url('assets/brian-schroer.jpg');
+  }
 
-.team-list--item.ariel {
-  background-image: url('assets/ariel-zhen.png');
-}
+  .team-list--item.avneet {
+    background-image: url('assets/avneet-chadha.jpg');
+  }
 
-.team-list--item.chris {
-  background-image: url('assets/chris-cortese.png');
-}
+  .team-list--item.cliff {
+    background-image: url('assets/cliff-crosland.png');
+  }
 
-.team-list--item.bill-soward {
-  background-image: url('assets/bill-soward.jpg');
-}
+  .team-list--item.michelle {
+    background-image: url('assets/michelle-carey.png');
+  }
 
-.team-list--item.husam-najib {
-  background-image: url('assets/husam-najib.jpg');
-}
+  .team-list--item.ariel {
+    background-image: url('assets/ariel-zhen.png');
+  }
 
-.team-list--item.keith-weber {
-  background-image: url('assets/keith-weber.jpg');
-}
+  .team-list--item.chris {
+    background-image: url('assets/chris-cortese.png');
+  }
 
-.team-list--item.laura-barrera-vera {
-  background-image: url('assets/laura-barrera-vera.jpg');
-}
+  .team-list--item.bill-soward {
+    background-image: url('assets/bill-soward.jpg');
+  }
 
-.team-list--item.arielle-robles {
-  background-image: url('assets/arielle-robles.jpg');
-}
+  .team-list--item.husam-najib {
+    background-image: url('assets/husam-najib.jpg');
+  }
 
-.team-list--item.chris-yang {
-  background-image: url('assets/chris-yang.jpg');
-}
+  .team-list--item.keith-weber {
+    background-image: url('assets/keith-weber.jpg');
+  }
 
-.team-list--item.stephen-soward {
-  background-image: url('assets/stephen-soward.png');
-}
+  .team-list--item.laura-barrera-vera {
+    background-image: url('assets/laura-barrera-vera.jpg');
+  }
 
-.team-list--item.jacob-frank {
-  background-image: url('assets/jacob-frank.jpg');
-}
+  .team-list--item.arielle-robles {
+    background-image: url('assets/arielle-robles.jpg');
+  }
 
-.team-list--item.fred-ciaramaglia {
-  background-image: url('assets/fred-ciaramaglia.jpg');
-}
+  .team-list--item.chris-yang {
+    background-image: url('assets/chris-yang.jpg');
+  }
 
-.team-list--item.rachel-poonsiriwong {
-  background-image: url('assets/rachel-poonsiriwong.jpg');
-}
+  .team-list--item.stephen-soward {
+    background-image: url('assets/stephen-soward.png');
+  }
 
-.team-list--item.ada-lau {
-  background-image: url('assets/ada-lau.jpg');
-}
+  .team-list--item.jacob-frank {
+    background-image: url('assets/jacob-frank.jpg');
+  }
 
-.team-list--item.amanda-liu {
-  background-image: url('assets/amanda-liu.jpg');
-}
+  .team-list--item.fred-ciaramaglia {
+    background-image: url('assets/fred-ciaramaglia.jpg');
+  }
 
-.team-list--item.ryan-rodriguez {
-  background-image: url('assets/ryan-rodriguez.png');
-}
+  .team-list--item.rachel-poonsiriwong {
+    background-image: url('assets/rachel-poonsiriwong.jpg');
+  }
 
-.team-list--item.isaac-chao {
-  background-image: url('assets/isaac-chao.jpg');
-}
+  .team-list--item.ada-lau {
+    background-image: url('assets/ada-lau.jpg');
+  }
 
-.team-list--item.jan-barnes {
-  background-image: url('assets/jan-barnes.jpg');
-}
+  .team-list--item.amanda-liu {
+    background-image: url('assets/amanda-liu.jpg');
+  }
 
-.team-list--item.lissa-dotty {
-  background-image: url('assets/lissa-dotty.jpg');
-}
+  .team-list--item.ryan-rodriguez {
+    background-image: url('assets/ryan-rodriguez.png');
+  }
 
-.team-list--item.jason-cheng {
-  background-image: url('assets/jason-cheng.jpg');
+  .team-list--item.isaac-chao {
+    background-image: url('assets/isaac-chao.jpg');
+  }
+
+  .team-list--item.jan-barnes {
+    background-image: url('assets/jan-barnes.jpg');
+  }
+
+  .team-list--item.lissa-dotty {
+    background-image: url('assets/lissa-dotty.jpg');
+  }
+
+  .team-list--item.jason-cheng {
+    background-image: url('assets/jason-cheng.jpg');
+  }
 }

--- a/src/legacy/layouts/app.scss
+++ b/src/legacy/layouts/app.scss
@@ -1,13 +1,5 @@
 @import '../stylesheets/utils/all';
 
-// Some best-practice CSS that's useful for most apps
-// Just remove them if they're not what you want
-html {
-  box-sizing: border-box;
-}
-
-html,
-body,
 .app {
   box-sizing: border-box;
   height: 100%;

--- a/src/legacy/stylesheets/utils/_mixins.scss
+++ b/src/legacy/stylesheets/utils/_mixins.scss
@@ -1,7 +1,11 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 // CALCULATE EMS
 
-@function calc-em($target-px, $context:$font-size) {
+// The default value for $context is set to the default font size on most
+// browsers.
+// Note: that this file is going away soon, so please ignore how this is bad for
+// accessibility reasons.
+@function calc-em($target-px, $context: 16px) {
   @return ($target-px / $context) * 1rem;
 }
 

--- a/src/legacy/stylesheets/utils/_typography.scss
+++ b/src/legacy/stylesheets/utils/_typography.scss
@@ -1,6 +1,11 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 // TYPEFACES
 
+// Disable this because we need to temporarily add extra specificity to all
+// legacy styles in the middle of the site transition. All the legacy styles and
+// code will go away soon.
+/* stylelint-disable max-nesting-depth */
+
 @import url('https://fonts.googleapis.com/css?family=Lato:300i,300,400,700');
 
 $font-family-base: 'Lato', 'Open Sans', 'Helvetica Neue', 'Arial', sans-serif;
@@ -17,120 +22,122 @@ $font-family-base: 'Lato', 'Open Sans', 'Helvetica Neue', 'Arial', sans-serif;
   word-wrap: break-word;
 }
 
-h1 {
-  color: $color-brand;
-  font-size: calc-em(72px);
-  hyphens: auto;
-  line-height: 1.1;
-  @include r_min_max($screen-xs, $screen-md) {
-    font-size: calc-em(60px);
+.app {
+  h1 {
+    color: $color-brand;
+    font-size: calc-em(72px);
+    hyphens: auto;
+    line-height: 1.1;
+    @include r_min_max($screen-xs, $screen-md) {
+      font-size: calc-em(60px);
+    }
+    @include r_max($screen-xs) {
+      font-size: calc-em(48px);
+    }
   }
-  @include r_max($screen-xs) {
-    font-size: calc-em(48px);
-  }
-}
 
-h2 {
-  color: $color-brand;
-  font-size: calc-em(50px);
-  font-weight: 300;
-  @include r_min_max($screen-xs, $screen-md) {
-    font-size: calc-em(42px);
+  h2 {
+    color: $color-brand;
+    font-size: calc-em(50px);
+    font-weight: 300;
+    @include r_min_max($screen-xs, $screen-md) {
+      font-size: calc-em(42px);
+    }
+    @include r_max($screen-xs) {
+      font-size: calc-em(36px);
+    }
   }
-  @include r_max($screen-xs) {
-    font-size: calc-em(36px);
-  }
-}
 
-h3 {
-  font-size: calc-em(28px);
-  @include r_min_max($screen-xs, $screen-md) {
-    font-size: calc-em(24px);
+  h3 {
+    font-size: calc-em(28px);
+    @include r_min_max($screen-xs, $screen-md) {
+      font-size: calc-em(24px);
+    }
+    @include r_max($screen-xs) {
+      font-size: calc-em(21px);
+    }
   }
-  @include r_max($screen-xs) {
+
+  h4 {
+    color: $color-brand;
     font-size: calc-em(21px);
+    @include r_min_max($screen-xs, $screen-md) {
+      font-size: calc-em(16px);
+    }
+    @include r_max($screen-xs) {
+      font-size: calc-em(15px);
+    }
   }
-}
 
-h4 {
-  color: $color-brand;
-  font-size: calc-em(21px);
-  @include r_min_max($screen-xs, $screen-md) {
-    font-size: calc-em(16px);
-  }
-  @include r_max($screen-xs) {
+  h5 {
     font-size: calc-em(15px);
+    @include r_min_max($screen-xs, $screen-md) {
+      font-size: calc-em(14px);
+    }
+    @include r_max($screen-xs) {
+      font-size: calc-em(13px);
+    }
   }
-}
 
-h5 {
-  font-size: calc-em(15px);
-  @include r_min_max($screen-xs, $screen-md) {
-    font-size: calc-em(14px);
+  p {
+    font-size: calc-em(15px);
+    margin-bottom: 10px;
+    @include r_min_max($screen-xs, $screen-md) {
+      font-size: calc-em(14px);
+    }
+    @include r_max($screen-xs) {
+      font-size: calc-em(13px);
+    }
   }
-  @include r_max($screen-xs) {
+
+  small {
     font-size: calc-em(13px);
+    @include r_min_max($screen-xs, $screen-md) {
+      font-size: calc-em(12px);
+    }
+    @include r_max($screen-xs) {
+      font-size: calc-em(12px);
+    }
   }
-}
 
-p {
-  font-size: calc-em(15px);
-  margin-bottom: 10px;
-  @include r_min_max($screen-xs, $screen-md) {
-    font-size: calc-em(14px);
+  a {
+    @include transition(all 0.2s);
+    color: $color-brand;
+    cursor: pointer;
+    text-decoration: none;
+
+    &:hover {
+      position: relative;
+      top: 1px;
+    }
   }
-  @include r_max($screen-xs) {
-    font-size: calc-em(13px);
+
+  em {
+    font-style: italic;
   }
-}
 
-small {
-  font-size: calc-em(13px);
-  @include r_min_max($screen-xs, $screen-md) {
-    font-size: calc-em(12px);
+  strong {
+    font-weight: 700;
   }
-  @include r_max($screen-xs) {
-    font-size: calc-em(12px);
+
+  button {
+    cursor: pointer;
+    font-family: $font-family-base;
   }
-}
 
-a {
-  @include transition(all 0.2s);
-  color: $color-brand;
-  cursor: pointer;
-  text-decoration: none;
-
-  &:hover {
-    position: relative;
-    top: 1px;
+  textarea,
+  input {
+    font-family: $font-family-base;
   }
-}
+  %hide-text {
+    display: inline-block;
+    overflow: hidden;
+    text-indent: 100%;
+    white-space: nowrap;
+  }
 
-em {
-  font-style: italic;
-}
-
-strong {
-  font-weight: 700;
-}
-
-button {
-  cursor: pointer;
-  font-family: $font-family-base;
-}
-
-textarea,
-input {
-  font-family: $font-family-base;
-}
-%hide-text {
-  display: inline-block;
-  overflow: hidden;
-  text-indent: 100%;
-  white-space: nowrap;
-}
-
-::selection {
-  background: transparentize($color-brand-light, 0.4);
-  color: $color-white;
+  ::selection {
+    background: transparentize($color-brand-light, 0.4);
+    color: $color-white;
+  }
 }

--- a/src/legacy/stylesheets/utils/_typography.scss
+++ b/src/legacy/stylesheets/utils/_typography.scss
@@ -8,8 +8,7 @@ $font-family-base: 'Lato', 'Open Sans', 'Helvetica Neue', 'Arial', sans-serif;
 //////////////////////////////////////////////////////////////////////////////////////////
 // FONT STYLES
 
-html,
-body {
+.app {
   color: $color-text;
   font-family: $font-family-base;
   font-size: $font-size;


### PR DESCRIPTION
You'll probably want to review the diff with "ignore whitespace differences" turned on, since I had to indent almost every legacy stylesheet.

While trying to add a new page on the Gatsby site for the new site design, I was hitting issues with global styles messing with the view of the new components that we've been developing in Storybook. This PR just changes the old stylesheets so that anything that was changing global styles (i.e. selectors that were only based on tag names and not classes) is now scoped under an `.app` class. There happens to be a `<div class="app">` in the old site that was the parent of every page, so it's safe to nest every selector under a `.app` class without changing the appearance of the page.

I hit one other issue with trying to get rid of global styles, which is that the old `_typography.scss` file was setting the font size of the root element. This has another, subtle global effect, which is that it changes the value of the [`rem`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#rem) unit. `rem` is like `em` except that it's always based on the font size of the root element (i.e., the `html` element) rather than the parent of the current element. Changing the font size of the parent element therefore changes the value of the `rem` unit everywhere, so I had to readjust all of the `rem` units back to what they were supposed to look like.

I think this should result in the site not changing at all, and I did manual, visual comparisons of each page in order to test it.

I'll submit a separate PR to actually introduce the new home page with our new components.