### PR TITLE
Create new home page component

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ For more specific documentation, visit one of the pages below:
 [Command-Line Quick Reference]: ./docs/command-line-quick-reference.md
 [Component Design System]: ./docs/component-design-system.md
 [How To Deploy]: ./docs/how-to-deploy.md
+
+## Staging website
+
+We're currently in the process of developing a redesign of the sheltertech.org
+website! Until we are done and ready to flip the switch to the new design, we
+will be placing the new site pages under the `/new` URL path so that they can be
+easily previewed before we roll them out to the main site page routing.
+
+To view the current state of the new design on the staging website, please visit
+https://staging.sheltertech.org/new.

--- a/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.js
+++ b/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.js
@@ -17,11 +17,6 @@ const ImagePropType = PropTypes.shape({
   alt: PropTypes.string.isRequired,
 });
 
-const CTAButtonPropType = PropTypes.shape({
-  text: PropTypes.string.isRequired,
-  link: PropTypes.string.isRequired,
-});
-
 /* Subcomponents */
 
 const ParagraphBlock = ({ title, description }) => (
@@ -42,9 +37,9 @@ const CTABlock = ({ title, buttons }) => (
       <div className={s.ctaTitle}>{title}</div>
     </div>
     <div className={s.ctaButtonRow}>
-      {buttons.map((button) => (
-        <div className={s.ctaButtonRowItem} key={button.text}>
-          <Button text={button.text} internalLink={button.link} />
+      {buttons.map(({ text, internalLink, externalLink, onClick }) => (
+        <div className={s.ctaButtonRowItem} key={text}>
+          <Button {...{ text, internalLink, externalLink, onClick }} />
         </div>
       ))}
     </div>
@@ -53,7 +48,7 @@ const CTABlock = ({ title, buttons }) => (
 
 CTABlock.propTypes = {
   title: PropTypes.string.isRequired,
-  buttons: PropTypes.arrayOf(CTAButtonPropType).isRequired,
+  buttons: PropTypes.arrayOf(Button.propTypes).isRequired,
 };
 
 /* Main component */
@@ -142,7 +137,7 @@ ThreeParagraphBlock.propTypes = {
   image2: ImagePropType.isRequired,
   image3: ImagePropType.isRequired,
   ctaTitle: PropTypes.string.isRequired,
-  ctaButtons: PropTypes.arrayOf(CTAButtonPropType).isRequired,
+  ctaButtons: PropTypes.arrayOf(Button.propTypes).isRequired,
 };
 
 export default ThreeParagraphBlock;

--- a/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.stories.js
+++ b/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.stories.js
@@ -68,7 +68,7 @@ Gray.args = {
     "A monthly donation helps change the lives of those in need. Whether it’s providing free internet access to someone for the night or connecting a brand new shelter to the internet, your support will have a sustaining impact.",
   ctaTitle: "Volunteer, donate, or reach out to our partnerships team",
   ctaButtons: [
-    { text: "Become a Volunteer", link: "/foo" },
-    { text: "Donate", link: "/bar" },
+    { text: "Become a Volunteer", internalLink: "/foo" },
+    { text: "Donate", internalLink: "/bar" },
   ],
 };

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,0 +1,19 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import "../stylesheets/global.css";
+
+// TODO: This component should eventually have anything that is common to all
+// pages, such as the header and footers, but for now, we are mostly using this
+// to ensure that the global CSS file gets imported by all pages.
+const Layout = ({ children }) => <div>{children}</div>;
+
+Layout.propTypes = {
+  children: PropTypes.node,
+};
+
+Layout.defaultProps = {
+  children: null,
+};
+
+export default Layout;

--- a/src/pages/new/donate/index.js
+++ b/src/pages/new/donate/index.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+import Layout from "../../../components/layout";
+
+export default () => (
+  <Layout>This is a placeholder for the donate page.</Layout>
+);

--- a/src/pages/new/index.js
+++ b/src/pages/new/index.js
@@ -1,0 +1,48 @@
+import React from "react";
+
+import ThreeParagraphBlock from "../../components/grid-aware/ThreeParagraphBlock";
+import image1 from "../../components/grid-aware/ThreeParagraphBlock/stories/image1.png";
+import image2 from "../../components/grid-aware/ThreeParagraphBlock/stories/image2.png";
+import image3 from "../../components/grid-aware/ThreeParagraphBlock/stories/image3.png";
+import Layout from "../../components/layout";
+
+export default () => (
+  <Layout>
+    <ThreeParagraphBlock
+      title="Get involved"
+      paragraph1={{
+        title: "Volunteer",
+        description:
+          "Volunteers make our work possible. There are several ways to support our mission. Learn more and get involved.",
+      }}
+      paragraph2={{
+        title: "Partnerships",
+        description:
+          "We work with companies, nonprofits, and local governments to empower the community. Reach out to us.",
+      }}
+      paragraph3={{
+        title: "Donate",
+        description:
+          "Our programs are largely funded by donations from people who care about bridging the digital divide. Support ShelterTech today.",
+      }}
+      image1={{
+        url: image1,
+        alt: "Two volunteers working on a laptop together at a datathon.",
+      }}
+      image2={{
+        url: image2,
+        alt: "Team posing for a photo after a design workshop.",
+      }}
+      image3={{
+        url: image3,
+        alt: "Multiple volunteers working at a datathon.",
+      }}
+      ctaTitle="Volunteer, donate, or reach out to our partnerships team"
+      ctaButtons={[
+        { text: "Volunteer", internalLink: "/new/volunteer" },
+        { text: "Donate", internalLink: "/new/donate" },
+        { text: "Work with us", onClick: () => {} },
+      ]}
+    />
+  </Layout>
+);

--- a/src/pages/new/volunteer/index.js
+++ b/src/pages/new/volunteer/index.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+import Layout from "../../../components/layout";
+
+export default () => (
+  <Layout>This is a placeholder for the volunteer page.</Layout>
+);


### PR DESCRIPTION
https://app.clubhouse.io/sheltertech/story/1665/create-actual-new-home-page-component

I created a new page component for the new home page under `/new`. This will allow us to easily preview the new site without taking down the old one. As we develop the components on this page, we can gradually add them to this page component. Note that although this will look very similar to the Storybook stories, the data we are setting here for each of props is what will actually go on the site. After we integrate the CMS, these page components are the ones that should be querying the CMS, but for the initial site launch, we'll stick with the content being hardcoded here.

Eventually, when we do the site launch, we can make one final PR to delete all the old components and move everything from `/new` back to the parent level.

One other thing I did here was to create a `<Layout>` component. This is a convention that [Gatsby recommends](https://www.gatsbyjs.com/docs/layout-components/) for extracting common layout across multiple pages. When we actually build out the header and footer components, they probably would go here, but for now, I'm using it as a way to always ensure that the `global.css` file gets imported.

---

Here's a screenshot of the actual thing, where you can see that this is the real deal because of the little Intercom chat bubble icon on the bottom right:

<img width="1354" alt="Screen Shot 2020-10-18 at 5 24 16 PM" src="https://user-images.githubusercontent.com/1002748/96389904-d3a3dd00-1166-11eb-8fe2-6c594f02b9f4.png">
