### PR TITLE
Configure Storybook CSS modules to preserve original CSS names.

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -45,6 +45,7 @@ module.exports = {
           options: {
             importLoaders: 1,
             modules: true,
+            localIdentName: "[name]--[local]--[hash:base64:5]",
           },
         },
         {


### PR DESCRIPTION
This should hopefully make development in Storybook a lot easier.

<img width="645" alt="Screen Shot 2020-10-25 at 1 56 57 PM" src="https://user-images.githubusercontent.com/1002748/97118902-fdf71c80-16c9-11eb-985e-8d5e6824ebcc.png">

Our CSS Modules in Storybook was not configured to include parts of the original file and class names, which made it really difficult to tell which classes in the HTML corresponded to which classes in the raw CSS files. I was having difficulty configuring this until I realized that Gatsby is using `css-loader` v1.0.1, which has an older API for configuring the class names. Once I understood this, all I had to do was read the docs for [v1.0.1 to find out how it was set back then](https://github.com/webpack-contrib/css-loader/tree/v1.0.1#localidentname).