### PR TITLE
Correct black color to pure black.

### DIFF
--- a/src/stylesheets/global.css
+++ b/src/stylesheets/global.css
@@ -22,7 +22,7 @@
   --color-gray-700: #666;
   --color-gray-800: #484848;
   --color-gray-900: #212121;
-  --color-black: #202020;
+  --color-black: #000;
 
   /* Message Colors */
   --color-alert: #eb0000;


### PR DESCRIPTION
There was apparently a mistake in the [Design System Figma](https://www.figma.com/file/HLVHC58KwkcVFXkKAuY0ej/ShelterTech.org-Design-System?node-id=116%3A441), where the hex code for the black we're using was incorrectly stated as `#202020`, when in fact it should have been a pure `#000000`.

This corrects the value of `--color-black` in our global CSS variables file to match.