### PR TITLE
Decrease grid-row-gap in .programsWrapper media query to 30px

### DIFF
--- a/src/components/grid-aware/ProgramsBlock/ProgramsBlock.module.css
+++ b/src/components/grid-aware/ProgramsBlock/ProgramsBlock.module.css
@@ -69,7 +69,7 @@
 
 @media (--tablet-and-down) {
   .programsWrapper {
-    grid-row-gap: 40px;
+    grid-row-gap: 30px;
     grid-template-columns: 1fr;
     justify-items: center;
     margin-top: 30px;


### PR DESCRIPTION
According to Derek, the spacing between each program card in the mobile view should be 30px.