### PR TITLE
Add Modal component and integrate Mailchimp form

### DIFF
--- a/jest/loadershim.js
+++ b/jest/loadershim.js
@@ -2,3 +2,9 @@
 global.___loader = {
   enqueue: jest.fn(),
 };
+
+// Used to allow react-modal to work in tests.
+// https://github.com/facebook/react/issues/11565#issuecomment-427547413
+jest.mock("react-dom", () => ({
+  createPortal: (node) => node,
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -16332,6 +16332,11 @@
         }
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -29644,6 +29649,17 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-modal": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.2.tgz",
+      "integrity": "sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      }
     },
     "react-popper": {
       "version": "1.3.7",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "pure-react-carousel": "^1.27.6",
     "react": "^16.13.1",
     "react-burger-menu": "^2.9.0",
-    "react-helmet": "^6.1.0"
+    "react-helmet": "^6.1.0",
+    "react-modal": "^3.11.2"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/src/components/grid-aware/Modal/Modal.js
+++ b/src/components/grid-aware/Modal/Modal.js
@@ -1,0 +1,40 @@
+import PropTypes from "prop-types";
+import React from "react";
+import ReactModal from "react-modal";
+
+import s from "./Modal.module.css";
+import closeIcon from "./close-icon.svg";
+
+const Modal = ({ children, isOpen, setIsOpen, ariaHideApp, contentLabel }) => (
+  <ReactModal
+    className={s.content}
+    overlayClassName={s.overlay}
+    isOpen={isOpen}
+    onRequestClose={() => setIsOpen(false)}
+    ariaHideApp={ariaHideApp}
+    contentLabel={contentLabel}
+  >
+    <button
+      className={s.closeButton}
+      onClick={() => setIsOpen(false)}
+      type="button"
+    >
+      <img src={closeIcon} alt="Close" />
+    </button>
+    {children}
+  </ReactModal>
+);
+
+Modal.propTypes = {
+  children: PropTypes.node.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  setIsOpen: PropTypes.func.isRequired,
+  ariaHideApp: PropTypes.bool,
+  contentLabel: PropTypes.string.isRequired,
+};
+
+Modal.defaultProps = {
+  ariaHideApp: true,
+};
+
+export default Modal;

--- a/src/components/grid-aware/Modal/Modal.module.css
+++ b/src/components/grid-aware/Modal/Modal.module.css
@@ -1,0 +1,45 @@
+.overlay {
+  background-color: rgba(0, 0, 0, 0.5);
+  bottom: 0;
+  left: 0;
+  overflow: auto;
+  position: fixed;
+  right: 0;
+  top: 0;
+}
+
+.content {
+  background: var(--color-white);
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+  margin: 80px auto 40px;
+  max-width: 850px;
+  outline: none;
+  padding: 50px;
+  position: relative;
+}
+
+.closeButton {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  display: inline-block;
+  padding: 0;
+  position: absolute;
+  right: 30px;
+  top: 30px;
+}
+
+@media (--tablet-and-down) {
+  .content {
+    margin-left: 20px;
+    margin-right: 20px;
+    padding: 35px 25px;
+  }
+
+  .closeButton {
+    right: 25px;
+    top: 25px;
+  }
+}

--- a/src/components/grid-aware/Modal/Modal.stories.js
+++ b/src/components/grid-aware/Modal/Modal.stories.js
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+
+import Modal from "./Modal";
+
+export default {
+  title: "Grid-Aware/Modal",
+  component: Modal,
+};
+
+const Template = () => {
+  const [modalIsOpen, setModalIsOpen] = useState(true);
+  return (
+    <div>
+      <Modal
+        isOpen={modalIsOpen}
+        setIsOpen={setModalIsOpen}
+        /* Disable ariaHideApp in Storybook to suppress warning about not
+         * setting the app element.
+         * https://github.com/reactjs/react-modal/issues/576
+         */
+        ariaHideApp={false}
+        contentLabel="Example Modal"
+      >
+        <div style={{ font: "var(--font-body-medium)" }}>
+          <h1 style={{ font: "var(--font-headline)" }}>Work with Us</h1>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+        </div>
+      </Modal>
+      <div>
+        <button type="button" onClick={() => setModalIsOpen(!modalIsOpen)}>
+          Toggle Modal
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export const DefaultModal = Template.bind({});
+DefaultModal.args = {};

--- a/src/components/grid-aware/Modal/close-icon.svg
+++ b/src/components/grid-aware/Modal/close-icon.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 6L18 18" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/grid-aware/Modal/index.js
+++ b/src/components/grid-aware/Modal/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Modal";

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import ReactModal from "react-modal";
 
 import "../stylesheets/global.css";
 import { BurgerMenu, Navigation } from "./grid-aware/Navigation";
@@ -14,6 +15,9 @@ const Layout = ({ children }) => {
   const pageWrapperID = "page-wrapper";
   const outerContainerID = "outer-container";
   const [burgerMenuIsOpen, setBurgerMenuIsOpen] = useState(false);
+  useEffect(() => {
+    ReactModal.setAppElement(`#${outerContainerID}`);
+  }, []);
   return (
     <div id={outerContainerID}>
       <BurgerMenu

--- a/src/components/thirdparty/mailchimp/VolunteerSignupForm.css
+++ b/src/components/thirdparty/mailchimp/VolunteerSignupForm.css
@@ -1,0 +1,34 @@
+/* This file contains global styles because we are overriding the default styles
+ * that come from Mailchimp. */
+/* stylelint-disable selector-max-id */
+
+#mc_embed_signup form {
+  padding: 0 !important;
+}
+
+#mc_embed_signup .mc-field-group {
+  margin-bottom: 39px;
+  padding-bottom: 0 !important;
+}
+
+#mc_embed_signup .mc-field-group label {
+  font: var(--font-caption);
+  margin-bottom: 10px !important;
+}
+
+#mc_embed_signup .mc-field-group input {
+  border: 1px solid var(--color-gray-400);
+  border-radius: 0;
+  font: var(--font-body-small);
+  padding: 16px 17px 15px !important;
+}
+
+#mc_embed_signup .button {
+  background-color: var(--color-sheltertech-blue) !important;
+  border-radius: 0 !important;
+  color: var(--color-white) !important;
+  font: var(--font-action) !important;
+  height: auto !important;
+  padding: 16px 40px !important;
+  text-transform: uppercase;
+}

--- a/src/components/thirdparty/mailchimp/VolunteerSignupForm.js
+++ b/src/components/thirdparty/mailchimp/VolunteerSignupForm.js
@@ -1,0 +1,62 @@
+import React from "react";
+
+import "./VolunteerSignupForm.css";
+import s from "./VolunteerSignupForm.module.css";
+
+/* eslint-disable react/no-danger */
+// This entire file is just about embedding an external form
+
+const rawInnerHtml = {
+  __html: `
+<!-- Begin Mailchimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+	/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<div id="mc_embed_signup">
+<form action="https://sheltertech.us19.list-manage.com/subscribe/post?u=c47829732a0bea5c8e8a94604&amp;id=08f60e42ef" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+
+<div class="mc-field-group">
+	<label for="mce-EMAIL">Email Address </label>
+	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+</div>
+<div class="mc-field-group">
+	<label for="mce-FNAME">First Name </label>
+	<input type="text" value="" name="FNAME" class="" id="mce-FNAME">
+</div>
+<div class="mc-field-group">
+	<label for="mce-LNAME">Last Name </label>
+	<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
+</div>
+<div class="mc-field-group">
+	<label for="mce-MMERGE12">Volunteer Interests </label>
+	<input type="text" value="" name="MMERGE12" class="" id="mce-MMERGE12">
+</div>
+	<div id="mce-responses" class="clear">
+		<div class="response" id="mce-error-response" style="display:none"></div>
+		<div class="response" id="mce-success-response" style="display:none"></div>
+	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_c47829732a0bea5c8e8a94604_08f60e42ef" tabindex="-1" value=""></div>
+    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+</form>
+</div>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';fnames[6]='MMERGE6';ftypes[6]='text';fnames[7]='MMERGE7';ftypes[7]='number';fnames[8]='MMERGE8';ftypes[8]='date';fnames[9]='MMERGE9';ftypes[9]='text';fnames[10]='LGL_SAL';ftypes[10]='text';fnames[11]='LGL_ID';ftypes[11]='text';fnames[12]='MMERGE12';ftypes[12]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<!--End mc_embed_signup-->
+`,
+};
+
+const VolunteerSignupForm = () => (
+  <div>
+    <h1 className={s.title}>Work With Us</h1>
+    <p className={s.description}>
+      Thank you for your interest in partnering with ShelterTech! Enter your
+      contact information below and we&apos;ll get back to you shortly.
+    </p>
+    <div dangerouslySetInnerHTML={rawInnerHtml} />
+  </div>
+);
+export default VolunteerSignupForm;

--- a/src/components/thirdparty/mailchimp/VolunteerSignupForm.module.css
+++ b/src/components/thirdparty/mailchimp/VolunteerSignupForm.module.css
@@ -1,0 +1,11 @@
+.title {
+  font: var(--font-headline);
+  margin-bottom: 20px;
+  margin-top: 0;
+}
+
+.description {
+  font: var(--font-body-medium);
+  margin-bottom: 40px;
+  margin-top: 0;
+}

--- a/src/components/thirdparty/mailchimp/VolunteerSignupForm.stories.js
+++ b/src/components/thirdparty/mailchimp/VolunteerSignupForm.stories.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+import VolunteerSignupForm from "./VolunteerSignupForm";
+
+export default {
+  title: "Third Party/Mailchimp/VolunteerSignupForm",
+  component: VolunteerSignupForm,
+};
+
+const Template = () => (
+  <div style={{ maxWidth: "850px", padding: "50px" }}>
+    <p
+      style={{
+        fontStyle: "italic",
+        backgroundColor: "var(--color-gray-300)",
+        padding: "15px",
+      }}
+    >
+      Note: This is a real form, and submitting it will really subscribe you to
+      a Mailchimp list.
+    </p>
+    <VolunteerSignupForm />
+  </div>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/pages/new/index.js
+++ b/src/pages/new/index.js
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 
 import ArticleSpotlightCard from "../../components/grid-aware/ArticleSpotlightCard";
 import articleSpotlightImage from "../../components/grid-aware/ArticleSpotlightCard/stories/background.png";
 import BlockQuoteBlock from "../../components/grid-aware/BlockQuoteBlock/BlockQuoteBlock";
 import HomePageLargeParagraph from "../../components/grid-aware/HomePageLargeParagraph";
+import Modal from "../../components/grid-aware/Modal";
 import PartnersAndSponsorsBlock from "../../components/grid-aware/PartnersAndSponsorsBlock";
 import benetechLogo from "../../components/grid-aware/PartnersAndSponsorsBlock/stories/benetech-logo.png";
 import ciscoLogo from "../../components/grid-aware/PartnersAndSponsorsBlock/stories/cisco-logo.png";
@@ -27,168 +28,179 @@ import videoHeaderImage from "../../components/grid-aware/VideoHeader/stories/Vi
 import VideoSpotlightBlock from "../../components/grid-aware/VideoSpotlightBlock";
 import videoSpotlightBlockImage from "../../components/grid-aware/VideoSpotlightBlock/stories/VideoSpotlightBlock.png";
 import Layout from "../../components/layout";
+import VolunteerSignupForm from "../../components/thirdparty/mailchimp/VolunteerSignupForm";
 
-export default () => (
-  <Layout>
-    <VideoHeader
-      title="Less than half of nearly 10,000 people experiencing homelessness in the Bay Area have reliable access to the internet."
-      description="ShelterTech is a nonprofit organization dedicated to supporting people who are experiencing homelessness or housing insecurity by leveraging technology and connectivity."
-      image={videoHeaderImage}
-      ctaButtons={[
-        { text: "Donate", internalLink: "/new/donate" },
-        { text: "Volunteer", internalLink: "/new/volunteer" },
-      ]}
-      playButtonLink="https://www.youtube.com/watch?v=KCduRWJ1hQo"
-    />
-    <HomePageLargeParagraph
-      title="We believe connectivity is a human right."
-      description="Access to the internet and technology makes it possible for people to find a job, human services, and contact family and friends."
-    />
-    <ThreeParagraphBlock
-      title="Get involved"
-      paragraph1={{
-        title: "Volunteer",
-        description:
-          "Volunteers make our work possible. There are several ways to support our mission. Learn more and get involved.",
-      }}
-      paragraph2={{
-        title: "Partnerships",
-        description:
-          "We work with companies, nonprofits, and local governments to empower the community. Reach out to us.",
-      }}
-      paragraph3={{
-        title: "Donate",
-        description:
-          "Our programs are largely funded by donations from people who care about bridging the digital divide. Support ShelterTech today.",
-      }}
-      image1={{
-        url: image1,
-        alt: "Two volunteers working on a laptop together at a datathon.",
-      }}
-      image2={{
-        url: image2,
-        alt: "Team posing for a photo after a design workshop.",
-      }}
-      image3={{
-        url: image3,
-        alt: "Multiple volunteers working at a datathon.",
-      }}
-      ctaTitle="Volunteer, donate, or reach out to our partnerships team"
-      ctaButtons={[
-        { text: "Volunteer", internalLink: "/new/volunteer" },
-        { text: "Donate", internalLink: "/new/donate" },
-        { text: "Work with us", onClick: () => {} },
-      ]}
-    />
-    <ProgramsBlock
-      title="Our programs"
-      programs={[
-        {
-          theme: "dark",
-          image: shelterConnectImg,
-          imageAlt: "Image of ShelterTech booth with 4 volunteers smiling.",
-          title: "ShelterConnect",
+export default () => {
+  const [volunteerFormIsOpen, setVolunteerFormIsOpen] = useState(false);
+  return (
+    <Layout>
+      <Modal
+        isOpen={volunteerFormIsOpen}
+        setIsOpen={setVolunteerFormIsOpen}
+        contentLabel="Volunteer"
+      >
+        <VolunteerSignupForm />
+      </Modal>
+      <VideoHeader
+        title="Less than half of nearly 10,000 people experiencing homelessness in the Bay Area have reliable access to the internet."
+        description="ShelterTech is a nonprofit organization dedicated to supporting people who are experiencing homelessness or housing insecurity by leveraging technology and connectivity."
+        image={videoHeaderImage}
+        ctaButtons={[
+          { text: "Donate", internalLink: "/new/donate" },
+          { text: "Volunteer", internalLink: "/new/volunteer" },
+        ]}
+        playButtonLink="https://www.youtube.com/watch?v=KCduRWJ1hQo"
+      />
+      <HomePageLargeParagraph
+        title="We believe connectivity is a human right."
+        description="Access to the internet and technology makes it possible for people to find a job, human services, and contact family and friends."
+      />
+      <ThreeParagraphBlock
+        title="Get involved"
+        paragraph1={{
+          title: "Volunteer",
           description:
-            "Every year, our ShelterConnect program provides 3XXX homeless and housing insecure people with free and unlimited internet access and we plan to provide every homeless individual with the digital infrastructure that meets their needs by 2024.",
-        },
-        {
-          theme: "dark",
-          image: sfServiceGuideImg,
-          imageAlt:
-            "Image of the back of two people sitting where the woman on the left is pointing to the monitor of a Macbook as the man observes.",
-          title: "SF Service Guide",
+            "Volunteers make our work possible. There are several ways to support our mission. Learn more and get involved.",
+        }}
+        paragraph2={{
+          title: "Partnerships",
           description:
-            "Anyone with access to a smartphone, tablet, or computer can utilize this online directory of human services provided in San Francisco.",
-        },
-        {
-          theme: "dark",
-          image: communityDevelopmentImg,
-          imageAlt: "Image of ShelterTech community member smiling.",
-          title: "Community Development",
+            "We work with companies, nonprofits, and local governments to empower the community. Reach out to us.",
+        }}
+        paragraph3={{
+          title: "Donate",
           description:
-            "We depend on Community Representatives to inform our work from their lived experiences and rely on volunteers to continuously updated the resources we develop.",
-        },
-      ]}
-    />
-    <VideoSpotlightBlock
-      eyebrowText="Our Impact"
-      description="Over 3,000 people have daily internet access in local shelters and resource centers."
-      button={{ text: "View Annual Report", internalLink: "/foo" }}
-      image={{
-        url: videoSpotlightBlockImage,
-        alt: "Video spotlight of Aaron speaking.",
-      }}
-      playButtonLink="/foo"
-    />
-    <TitleBlock title="Voices from the community" />
-    <BlockQuoteBlock
-      quotes={[
-        {
-          quote:
-            "We've heard from San Franciscans, including as part of our recent strategic planning community outreach that it's hard to know where to go when you're looking for supportive services. It's hard to know where to start, and hard to navigate different resources to find accurate information. We're glad to be supporting ShelterTech and the broader community to build SF Service Guide - a one-stop, reliable place to help connect residents to the services they need.",
-          attribution:
-            "Barry Roeder, Mayor's Office of Housing and Community Development",
-        },
-        {
-          quote:
-            "Wi-fi has been a top request among young people here at Larkin Street. Now that we have it with ShelterTech we are seeing more young people come in and stay around and get the things they need so that they can move past homelessness, permanently.",
-          attribution:
-            "Veronica Pastore, Director of Communications, Larkin Street Youth Services",
-        },
-        {
-          quote:
-            "There’s an overwhelming number of resources for the vulnerable populations that live here and it’s important to have a place where they can go where they know all the information is accurate, up-to-date, and consistent with what their understanding has been of that particular resource. And if there are any changes that need to be made those will be reflected.",
-          attribution:
-            "Julie Rosenthal, Director of Social Services, Homeless Advocacy Project",
-        },
-      ]}
-    />
-    <PartnersAndSponsorsBlock
-      title="Partners and sponsors"
-      partnersAndSponsors={[
-        {
-          url: mohcdLogo,
-          alt:
-            "Logo of Mayor's Office of Housing and Community Development organization.",
-        },
-        {
-          url: justiceAndDiversityCenterLogo,
-          alt:
-            "Logo of Justice and Diversity Center of The Bar Association of San Francisco organization.",
-        },
-        {
-          url: benetechLogo,
-          alt: "Logo of Benetech nonprofit organization.",
-        },
-        {
-          url: larkinStreetLogo,
-          alt: "Logo of Larkin Street Youth Services nonprofit organization.",
-        },
-        {
-          url: sfFamiliesLogo,
-          alt:
-            "Logo of SF Families online public service directory organization.",
-        },
-        {
-          url: ciscoLogo,
-          alt: "Logo of Cisco Systems networking hardware company.",
-        },
-        {
-          url: pagerdutyLogo,
-          alt: "Logo of PagerDuty computer software company.",
-        },
-        {
-          url: uberLogo,
-          alt: "Logo of Uber Technologies Inc. company.",
-        },
-      ]}
-    />
-    <ArticleSpotlightCard
-      eyebrowText="Partnership Spotlight"
-      title="Digital Equity Team of San Francisco"
-      description="Free Fiber Initiative summary we're working together to find new and different ways of building lasting infrastructure"
-      button={{ text: "Read more", internalLink: "/foo" }}
-      backgroundImage={articleSpotlightImage}
-    />
-  </Layout>
-);
+            "Our programs are largely funded by donations from people who care about bridging the digital divide. Support ShelterTech today.",
+        }}
+        image1={{
+          url: image1,
+          alt: "Two volunteers working on a laptop together at a datathon.",
+        }}
+        image2={{
+          url: image2,
+          alt: "Team posing for a photo after a design workshop.",
+        }}
+        image3={{
+          url: image3,
+          alt: "Multiple volunteers working at a datathon.",
+        }}
+        ctaTitle="Volunteer, donate, or reach out to our partnerships team"
+        ctaButtons={[
+          { text: "Volunteer", internalLink: "/new/volunteer" },
+          { text: "Donate", internalLink: "/new/donate" },
+          { text: "Work with us", onClick: () => setVolunteerFormIsOpen(true) },
+        ]}
+      />
+      <ProgramsBlock
+        title="Our programs"
+        programs={[
+          {
+            theme: "dark",
+            image: shelterConnectImg,
+            imageAlt: "Image of ShelterTech booth with 4 volunteers smiling.",
+            title: "ShelterConnect",
+            description:
+              "Every year, our ShelterConnect program provides 3XXX homeless and housing insecure people with free and unlimited internet access and we plan to provide every homeless individual with the digital infrastructure that meets their needs by 2024.",
+          },
+          {
+            theme: "dark",
+            image: sfServiceGuideImg,
+            imageAlt:
+              "Image of the back of two people sitting where the woman on the left is pointing to the monitor of a Macbook as the man observes.",
+            title: "SF Service Guide",
+            description:
+              "Anyone with access to a smartphone, tablet, or computer can utilize this online directory of human services provided in San Francisco.",
+          },
+          {
+            theme: "dark",
+            image: communityDevelopmentImg,
+            imageAlt: "Image of ShelterTech community member smiling.",
+            title: "Community Development",
+            description:
+              "We depend on Community Representatives to inform our work from their lived experiences and rely on volunteers to continuously updated the resources we develop.",
+          },
+        ]}
+      />
+      <VideoSpotlightBlock
+        eyebrowText="Our Impact"
+        description="Over 3,000 people have daily internet access in local shelters and resource centers."
+        button={{ text: "View Annual Report", internalLink: "/foo" }}
+        image={{
+          url: videoSpotlightBlockImage,
+          alt: "Video spotlight of Aaron speaking.",
+        }}
+        playButtonLink="/foo"
+      />
+      <TitleBlock title="Voices from the community" />
+      <BlockQuoteBlock
+        quotes={[
+          {
+            quote:
+              "We've heard from San Franciscans, including as part of our recent strategic planning community outreach that it's hard to know where to go when you're looking for supportive services. It's hard to know where to start, and hard to navigate different resources to find accurate information. We're glad to be supporting ShelterTech and the broader community to build SF Service Guide - a one-stop, reliable place to help connect residents to the services they need.",
+            attribution:
+              "Barry Roeder, Mayor's Office of Housing and Community Development",
+          },
+          {
+            quote:
+              "Wi-fi has been a top request among young people here at Larkin Street. Now that we have it with ShelterTech we are seeing more young people come in and stay around and get the things they need so that they can move past homelessness, permanently.",
+            attribution:
+              "Veronica Pastore, Director of Communications, Larkin Street Youth Services",
+          },
+          {
+            quote:
+              "There’s an overwhelming number of resources for the vulnerable populations that live here and it’s important to have a place where they can go where they know all the information is accurate, up-to-date, and consistent with what their understanding has been of that particular resource. And if there are any changes that need to be made those will be reflected.",
+            attribution:
+              "Julie Rosenthal, Director of Social Services, Homeless Advocacy Project",
+          },
+        ]}
+      />
+      <PartnersAndSponsorsBlock
+        title="Partners and sponsors"
+        partnersAndSponsors={[
+          {
+            url: mohcdLogo,
+            alt:
+              "Logo of Mayor's Office of Housing and Community Development organization.",
+          },
+          {
+            url: justiceAndDiversityCenterLogo,
+            alt:
+              "Logo of Justice and Diversity Center of The Bar Association of San Francisco organization.",
+          },
+          {
+            url: benetechLogo,
+            alt: "Logo of Benetech nonprofit organization.",
+          },
+          {
+            url: larkinStreetLogo,
+            alt: "Logo of Larkin Street Youth Services nonprofit organization.",
+          },
+          {
+            url: sfFamiliesLogo,
+            alt:
+              "Logo of SF Families online public service directory organization.",
+          },
+          {
+            url: ciscoLogo,
+            alt: "Logo of Cisco Systems networking hardware company.",
+          },
+          {
+            url: pagerdutyLogo,
+            alt: "Logo of PagerDuty computer software company.",
+          },
+          {
+            url: uberLogo,
+            alt: "Logo of Uber Technologies Inc. company.",
+          },
+        ]}
+      />
+      <ArticleSpotlightCard
+        eyebrowText="Partnership Spotlight"
+        title="Digital Equity Team of San Francisco"
+        description="Free Fiber Initiative summary we're working together to find new and different ways of building lasting infrastructure"
+        button={{ text: "Read more", internalLink: "/foo" }}
+        backgroundImage={articleSpotlightImage}
+      />
+    </Layout>
+  );
+};


### PR DESCRIPTION
# Overview
This got a bit more complicated and messier than I had wanted, but I think this is in good enough shape to start reviewing.

This really does a few things at once, all related to the Mailchimp form modals on the site:

1. It adds the [`react-modal`](https://github.com/reactjs/react-modal) library, and it sets up a standalone, reusable Modal component that can be used for other things in our site.
2. It integrates an embedded Mailchimp form for the Volunteer signup page, which I also turned into a separate Storybook component.
3. It adds these to the Home page, specifically for the Volunteer button on the Three Paragraph Block component, which also involved setting up some React state on the Home page.

## Modal Component

<img width="1152" alt="Screen Shot 2020-11-11 at 8 56 13 AM" src="https://user-images.githubusercontent.com/1002748/98840649-e6bf6b00-23fb-11eb-823e-bde76fb5b2be.png">

https://github.com/ShelterTechSF/sheltertech.org/commit/f9f6f6e4ee6c209795ecee7a106e2fc699d9eaca

I added a standalone Modal component to `src/components/grid-aware/Modal` based on the styles found in our [Figma designs](https://www.figma.com/file/HLVHC58KwkcVFXkKAuY0ej/ShelterTech.org-Design-System?node-id=1746%3A100).

This component just sets up the "outer" parts of the modal, and it expects the insides to be populated by the caller via the children. Specifically, this component sets up the overlay, which is the gray, partially transparent background, the modal container itself, and the close button. It's stateless, so it expects that its state is managed by its parent, passing in the `isOpen` prop as well as the `setIsOpen` function prop.

There's some weird stuff going on with this `ReactModal.setAppElement()` thing, which is something that the library [uses for accessibility purposes](http://reactcommunity.org/react-modal/accessibility/), where it wants to know the top-level element containing the application, but not containing the modal itself, so that can indicate to screen readers that the app element should be "disabled" when the modal is open. For us, unfortunately, this causes a chicken-and-the-egg problem, because on the very first render, our modal component is actually rendered _before_ the app element, meaning that if you try setting the app element before the app element is actually instantiated on the page, react-modal will hit an error. In Storybook, I worked around this by disabling the accessibility feature, but in our actual app, I had to do something weird where I used `useEffect()` to only set the app element after the first render.

I haven't fully researched all of the properties from react-modal, and it's possible that we may want to set a few more of those, so I can look into that next.

## Mailchimp form

<img width="954" alt="Screen Shot 2020-11-11 at 9 05 53 AM" src="https://user-images.githubusercontent.com/1002748/98841562-25a1f080-23fd-11eb-91a6-e9597e8abc10.png">

https://github.com/ShelterTechSF/sheltertech.org/commit/5d63d660c60006960dae64876958958717ce432b

This does a direct embedding of the Mailchimp forms using the snippet that we get directly from Mailchimp. Initially, I thought that this would be more maintainable, since it allows the non-technical teams to just send the technical team a direct copy of the snippets from Mailchimp, but this got a bit messier than I expected with overriding styles, and I also realized that the snippets just directly contain the input fields, rather than totally generating them at runtime with JavaScript.

Let me at least explain what's going on in the current approach, regardless of what we choose to do with this in the future. The first is that I am using [React's `dangerouslySetInnerHTML`](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml) prop, which allows you to embed any raw HTML as a string, including in-document `<style>` or `<script>` tags. Next, I have two different CSS files: a CSS modules file and then a non-module, global CSS file. The former is for the title and the description of the form, which do not come with the Mailchimp embed code, and the latter is for overriding the styles from Mailchimp.

I made liberal use of `!important`, since Mailchimp has some pretty high-specificity styles, although I probably could have increased my own specificity by adding an extra global CSS class to wrap the whole thing. I had to duplicate our site styles for the buttons and input elements, since I had to make them apply to and override Mailchimp's styles.

## Adding the modal to the Home page

<img width="1323" alt="Screen Shot 2020-11-11 at 9 25 08 AM" src="https://user-images.githubusercontent.com/1002748/98843478-e3c67980-23ff-11eb-8000-30828e0e4e71.png">

https://github.com/ShelterTechSF/sheltertech.org/commit/552348018df15a3191d314cdc75d97c88380a7c0

This was mostly straightforward, but I did have to ident almost every line in the Home page source code, since I needed to set up some React state with `useState()` to control the modal `isOpen` prop. For me, rebasing this branch on top of `main` has been a bit of a pain, since I'm constantly getting merge conflicts, but I don't think there's much I can do here until this is merged in.

## Things that still need to be addressed

1. The form submission doesn't feel great, since it does an actual page load and takes you off our site and onto Mailchimp:

<img width="1053" alt="Screen Shot 2020-11-11 at 9 27 13 AM" src="https://user-images.githubusercontent.com/1002748/98843669-21c39d80-2400-11eb-8126-7c787f0f5e57.png">

  @derekfidler, I'm guessing this is not a great UX, so maybe we really should just replace the embedded form with our own, so that we can handle the form submission entirely in JavaScript.

2. There's some weird re-rendering and pop-in that happens when the modal opens on the actual Home page. I'm guessing that for some reason, a re-render is occurring for all the elements on the base Home page, and because our images are getting reloaded, it causes the page to re-layout with the images popping in and out, shifting elements on the page.

3. The Mailchimp form styles are completely not loading in Firefox for some reason.

4. I am apparently failing some tests, which I think is related to https://github.com/reactjs/react-modal/issues/553.