### PR TITLE
Fix image alignment on mobile view for TwoParagraphBlock component

### DIFF
--- a/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
+++ b/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
@@ -84,6 +84,7 @@
   .gridAreaImage {
     margin-right: -40px;
     margin-top: 40px;
+    text-align: right;
   }
 }
 

--- a/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
+++ b/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
@@ -82,8 +82,8 @@
   }
 
   .gridAreaImage {
+    margin-right: -40px;
     margin-top: 40px;
-    text-align: right;
   }
 }
 
@@ -123,7 +123,6 @@
   }
 
   .image1Wrapper {
-    left: 40px;
     margin-bottom: 0;
     position: relative;
   }

--- a/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
+++ b/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
@@ -125,7 +125,6 @@
 
   .image1Wrapper {
     margin-bottom: 0;
-    position: relative;
   }
 }
 


### PR DESCRIPTION
I used negative margins to stick the image to the right of the screen but as the viewport shrinks it'll align the image with the text and resize accordingly.