### PR TITLE
Add broader set of viewports in Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import { action } from "@storybook/addon-actions";
+import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 
 import "../src/stylesheets/global.css";
 
@@ -32,4 +33,8 @@ export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   // If this is left to its default value of 'padded', then it interferes with the mobile views.
   layout: "fullscreen",
+  viewport: {
+    // Add more viewports based on real devices.
+    viewports: INITIAL_VIEWPORTS,
+  },
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@storybook/addon-essentials": "^6.0.21",
     "@storybook/addon-links": "^6.0.21",
     "@storybook/addon-storyshots": "^6.0.26",
+    "@storybook/addon-viewport": "^6.0.21",
     "@storybook/react": "^6.0.21",
     "babel-jest": "^26.6.0",
     "babel-loader": "^8.1.0",


### PR DESCRIPTION
This has been bothering me for a while, but we haven't had a viewport in Storybook that actually matched the size of the mobile designs in Figma, which is 375px. For this PR, I followed the instructions in https://storybook.js.org/docs/react/essentials/viewport#use-detailed-set-of-devices to add a larger set of device viewports. You can see what this expands to in the following screenshot:

<img width="398" alt="Screen Shot 2020-11-16 at 8 49 00 PM" src="https://user-images.githubusercontent.com/1002748/99348540-b12cde80-284e-11eb-8ca4-db40b40e2139.png">

The constant that I imported in this PR is defined [here](https://github.com/storybookjs/storybook/blob/5a257808c3fdf03b34c47bded5b9d1472e03e17e/addons/viewport/src/defaults.ts#L3), so if we feel that this is too overwhelming, I can cut it down to a smaller set of device types. Also, if we feel that having to think about the actual device screen names is too much, I could go back to the original list but just add a "Medium mobile" viewport size that has a width of 375px.

Let me know what you think!