### PR TITLE
Integrate Little Green Light donation form

### DIFF
--- a/src/components/grid-aware/DonationBlock/DonationBlock.js
+++ b/src/components/grid-aware/DonationBlock/DonationBlock.js
@@ -1,0 +1,71 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import s from "./DonationBlock.module.css";
+
+const rawLGLForm = {
+  // There are two manual modifications to this snippet from Little Green Light:
+  // - The height has been manually modified, since the original value didn't seem
+  //   to work. Note that Firefox's text box sizes seem to be slightly larger,
+  //   so the height needs to be large enough to accommodate Firefox
+  // - Scrolling has been enabled, since in a worst-case situation, we don't
+  //   want the submit button to be cut off and unable to be scrolled to.
+  __html: `
+<iframe onload="window.parent.scrollTo(0,0)" height="1040" allowTransparency="true" frameborder="0" scrolling="yes" style="width:100%;border:none"  src="https://secure.lglforms.com/form_engine/s/0wDrXsUXwzxrT32_RHQGrw"><a href="https://secure.lglforms.com/form_engine/s/0wDrXsUXwzxrT32_RHQGrw">Fill out my LGL Form!</a></iframe>
+`,
+};
+
+const LGLForm = () => (
+  // eslint-disable-next-line react/no-danger
+  <div className={s.formWrapper} dangerouslySetInnerHTML={rawLGLForm} />
+);
+
+const DonationBlock = ({
+  mainTitle,
+  mainDescription,
+  whyDonateTitle,
+  whyDonateList,
+  impactTitle,
+  impactList,
+}) => (
+  <div className={s.bleedWrapper}>
+    <div className={s.gridParent}>
+      <div className={s.gridAreaHeadline}>
+        <h1 className={s.mainTitle}>{mainTitle}</h1>
+        <div className={s.mainDescription}>{mainDescription}</div>
+      </div>
+      <div className={s.gridAreaForm}>
+        <LGLForm />
+      </div>
+      <div className={s.gridAreaDescription}>
+        <h2 className={s.whyDonateTitle}>{whyDonateTitle}</h2>
+        <ul className={s.list}>
+          {whyDonateList.map((reason) => (
+            <li className={s.listItem} key={reason}>
+              {reason}
+            </li>
+          ))}
+        </ul>
+        <h2 className={s.impactTitle}>{impactTitle}</h2>
+        <ul className={s.list}>
+          {impactList.map((reason) => (
+            <li className={s.listItem} key={reason}>
+              {reason}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </div>
+);
+
+DonationBlock.propTypes = {
+  mainTitle: PropTypes.string.isRequired,
+  mainDescription: PropTypes.string.isRequired,
+  whyDonateTitle: PropTypes.string.isRequired,
+  whyDonateList: PropTypes.arrayOf(PropTypes.string).isRequired,
+  impactTitle: PropTypes.string.isRequired,
+  impactList: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default DonationBlock;

--- a/src/components/grid-aware/DonationBlock/DonationBlock.module.css
+++ b/src/components/grid-aware/DonationBlock/DonationBlock.module.css
@@ -1,0 +1,84 @@
+/* Bleed wrapper */
+
+.bleedWrapper {
+  display: grid;
+  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  margin: 60px auto 120px;
+  max-width: var(--grid-bleed-max-width);
+}
+
+
+/* Main grid */
+
+.gridParent {
+  column-gap: var(--grid-column-gap);
+  display: grid;
+  grid-column: 2;
+  grid-template-columns: repeat(var(--grid-column-count), minmax(0, 1fr));
+  grid-template-rows: max-content auto; /* TODO: Richard doesn't understand why this works */
+}
+
+.gridAreaHeadline {
+  grid-column: 1 / span 6;
+  grid-row: 1;
+}
+
+.gridAreaForm {
+  grid-column: 7 / span 6;
+  grid-row: 1 / span 2;
+}
+
+.gridAreaDescription {
+  grid-column: 1 / span 6;
+  grid-row: 2;
+}
+
+
+/* Subcomponents */
+
+.mainTitle {
+  font: var(--font-headline);
+  margin-bottom: 0;
+  margin-top: 5px;
+}
+
+.mainDescription {
+  font: var(--font-subtitle);
+  margin-top: 15px;
+}
+
+.whyDonateTitle {
+  font: var(--font-subtitle);
+  margin-bottom: 0;
+  margin-top: 40px;
+}
+
+.impactTitle {
+  font: var(--font-headline);
+  margin-bottom: 0;
+  margin-top: 80px;
+}
+
+.list {
+  font: var(--font-body-medium);
+  list-style: url('./list-marker.svg');
+  margin-bottom: 0;
+  margin-top: 40px;
+  padding-left: 40px;
+}
+
+.listItem {
+  /* Used to manually horizontally center list marker. Note that Firefox and
+   * Chrome have subtly different ways of laying out the marker, so it's not
+   * possible to perfectly center this in all browsers. */
+  padding-left: 10px;
+}
+
+.listItem:not(:first-child) {
+  margin-top: 1em;
+}
+
+.formWrapper {
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
+  padding: 30px 0;
+}

--- a/src/components/grid-aware/DonationBlock/DonationBlock.module.css
+++ b/src/components/grid-aware/DonationBlock/DonationBlock.module.css
@@ -7,6 +7,12 @@
   max-width: var(--grid-bleed-max-width);
 }
 
+@media (--tablet-and-down) {
+  .bleedWrapper {
+    display: block;
+    margin: 50px auto 80px;
+  }
+}
 
 /* Main grid */
 
@@ -33,6 +39,27 @@
   grid-row: 2;
 }
 
+@media (--tablet-and-down) {
+  .gridParent {
+    column-gap: 0;
+    grid-template-columns: 20px 1fr 20px;
+  }
+
+  .gridAreaHeadline {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .gridAreaForm {
+    grid-column: 1 / span 3;
+    grid-row: 2;
+  }
+
+  .gridAreaDescription {
+    grid-column: 2;
+    grid-row: 3;
+  }
+}
 
 /* Subcomponents */
 
@@ -81,4 +108,24 @@
 .formWrapper {
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
   padding: 30px 0;
+}
+
+@media (--tablet-and-down) {
+  .mainTitle {
+    margin-top: 0;
+  }
+
+  .impactTitle {
+    margin-top: 50px;
+  }
+
+  .list {
+    margin-top: 25px;
+    padding-left: 25px;
+  }
+
+  .formWrapper {
+    box-shadow: 0 7.14286px 19.0476px rgba(0, 0, 0, 0.2);
+    margin-top: 50px;
+  }
 }

--- a/src/components/grid-aware/DonationBlock/DonationBlock.stories.js
+++ b/src/components/grid-aware/DonationBlock/DonationBlock.stories.js
@@ -1,0 +1,49 @@
+import React from "react";
+import DonationBlock from "./DonationBlock";
+
+export default {
+  title: "Grid-Aware/DonationBlock",
+  component: DonationBlock,
+};
+
+const Template = ({
+  mainTitle,
+  mainDescription,
+  whyDonateTitle,
+  whyDonateList,
+  impactTitle,
+  impactList,
+}) => (
+  <DonationBlock
+    mainTitle={mainTitle}
+    mainDescription={mainDescription}
+    whyDonateTitle={whyDonateTitle}
+    whyDonateList={whyDonateList}
+    impactTitle={impactTitle}
+    impactList={impactList}
+  />
+);
+
+export const Default = Template.bind({});
+
+Default.args = {
+  mainTitle: "Donate today",
+  mainDescription:
+    "Your support will address digital inequity for an underserved community that does not have access to the internet and essential digital services.",
+  whyDonateTitle: "Why give to ShelterTech?",
+  whyDonateList: [
+    "Our work depends on regular contributions from donors like you.",
+    "People experiencing homelessness and housing insecurity will have access to free internet and essential digital services.",
+    "We serve over 3,000 users on a daily basis and we’re always working to grow our network and deepen its capabilities.",
+    "These funds provide our advisory Community Representatives a stipend for their work.",
+    "Our organization is built on the belief that everyone has the right to connectivity.",
+  ],
+  impactTitle: "Your impact",
+  impactList: [
+    "$40 will go to a single Community Representative for their time conducting a Datathon event.",
+    "$150 connects a bed to wifi for five years.",
+    "$200 to $300 pays for up to seven Community Representatives’ time for a either a research or Datathon event.",
+    "$500 covers hosting an entire Datathon, which provides food for all volunteers and Community Representatives.",
+    "Depending on the size, about $2,000 to $2,500 can wire an entire shelter.",
+  ],
+};

--- a/src/components/grid-aware/DonationBlock/index.js
+++ b/src/components/grid-aware/DonationBlock/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DonationBlock";

--- a/src/components/grid-aware/DonationBlock/list-marker.svg
+++ b/src/components/grid-aware/DonationBlock/list-marker.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="6" cy="6" r="4" stroke="#0025E4" stroke-width="4"/>
+</svg>

--- a/src/pages/new/donate/index.js
+++ b/src/pages/new/donate/index.js
@@ -1,7 +1,29 @@
 import React from "react";
 
+import DonationBlock from "../../../components/grid-aware/DonationBlock";
 import Layout from "../../../components/layout";
 
 export default () => (
-  <Layout>This is a placeholder for the donate page.</Layout>
+  <Layout>
+    <DonationBlock
+      mainTitle="Donate today"
+      mainDescription="Your support will address digital inequity for an underserved community that does not have access to the internet and essential digital services."
+      whyDonateTitle="Why give to ShelterTech?"
+      whyDonateList={[
+        "Our work depends on regular contributions from donors like you.",
+        "People experiencing homelessness and housing insecurity will have access to free internet and essential digital services.",
+        "We serve over 3,000 users on a daily basis and we’re always working to grow our network and deepen its capabilities.",
+        "These funds provide our advisory Community Representatives a stipend for their work.",
+        "Our organization is built on the belief that everyone has the right to connectivity.",
+      ]}
+      impactTitle="Your impact"
+      impactList={[
+        "$40 will go to a single Community Representative for their time conducting a Datathon event.",
+        "$150 connects a bed to wifi for five years.",
+        "$200 to $300 pays for up to seven Community Representatives’ time for a either a research or Datathon event.",
+        "$500 covers hosting an entire Datathon, which provides food for all volunteers and Community Representatives.",
+        "Depending on the size, about $2,000 to $2,500 can wire an entire shelter.",
+      ]}
+    />
+  </Layout>
 );


### PR DESCRIPTION
## Overview

This PR is an attempt at implementing the main component on the Donate page, which includes the Little Green Light form.

Note that it looks fairly different from the [Figma design](https://www.figma.com/file/kKaWvJvyzhNS9hD21v7Ei5/ShelterTech.org-2020?node-id=1680%3A115), since there's no way for me to style the embedded form from Little Green Light, since it's located in an `<iframe>`, and for security reasons, web browsers do not allow you to interact with the content in an iframe if it comes from a different domain name.

## Caveats and issues

This is not my ideal way of handling this, and there's a few things that make it quite awkward. Aside from the form content just having a different style (typography-wise), I think the major issue with this is the height of the iframe. For security reasons, one cannot query the iframe content for its height, so it's not possible for our site to query for how much vertical space is required for the iframe, even with JavaScript.

The original iframe embed code had scrolling turned off, but this has a major drawback where if we guess wrong for the iframe height, the bottom of the form will get cut off, and the submit button itself will be the first thing to be truncated. That's not great for getting donations from people. In this code, I enabled scrolling, since I thought that the risk of having the content be cut off would be too large, so it would be better to err on the side of showing a scrollbar internal to the iframe if that happens.

One annoying issue is that there just appears to be a bunch of empty space at the bottom of the iframe, below the Submit button, so even when the content appears to fit, there will be an internal scroll region.

The other thing I found problematic about this is that different web browsers will have a different content height. Firefox seems to occupy the most vertical space, while Chrome and Safari occupy less. We have to err on the side of fully containing the form on Firefox, which means that there will be excessive padding on Chrome and Safari.

Another problem I encountered is that the height of the form is dependent on the width of our iframe, and since we're already going for a two-column layout, we really only have half the horizontal space available. On narrower screens, the form itself will take up more vertical space because the input text fields will switch from two-column layout to a single-column layout.

Finally, on mobile, the form is very awkward to use, since the static, fixed height of the iframe — which I hand-tuned for desktop — is definitely too small for mobile, and there will always be scrolling in mobile.

If you have time, @derekfidler, I'd ask that you check out this branch and play around with it yourself to see if you have any opinions on what we should do here.

## Alternate plan?
I do have one idea for a completely different approach to this. According to https://help.littlegreenlight.com/article/224-advanced-pass-values-into-a-form-via-email, there's a way to prefill form fields from an email link, where you can place the form values in the query parameters of a URL for the form that's hosted on Little Green Light's site. We could possibly implement a pure React form on our end, and when a user submits the form on our site, instead of actually submitting a real form request, we would just take the user to LGL's site with the form fields prefilled with what the user already set on our site.

I think the main drawbacks with this approach is 1) we would have to be _very_ careful to not change the form definition in LGL at all, since the form fields just have names like `field_1`, `field_2`, etc., and 2) this is going to be a bit more work to implement, and we're already coming up pretty close to when we want the site shipped by, especially since I'm getting requests to have the site live by next Tuesday (11/24) for an email campaign.

## Screenshots
![screencapture-localhost-8000-new-donate-2020-11-18-20_46_57](https://user-images.githubusercontent.com/1002748/99622631-65f60580-29df-11eb-9969-0ec5a9d0eb2c.png)
<img width="377" alt="Screen Shot 2020-11-18 at 8 49 10 PM" src="https://user-images.githubusercontent.com/1002748/99622701-8920b500-29df-11eb-97c7-e452c1fabf93.png">

