### PR TITLE
Fix button noHover style.

### DIFF
--- a/src/components/inline/Button/Button.js
+++ b/src/components/inline/Button/Button.js
@@ -5,7 +5,7 @@ import React from "react";
 import s from "./Button.module.css";
 
 const Button = ({ text, externalLink, internalLink, onClick, noHover }) => {
-  const button = `${s.button} ${noHover} ? ${s.noHover}: ""}`;
+  const button = `${s.button} ${noHover ? s.noHover : ""}`;
 
   if (externalLink) {
     return (


### PR DESCRIPTION
There was a small bug here that caused some undesired characters to appear in the CSS class name:

<img width="550" alt="Screen Shot 2020-11-19 at 12 48 14 AM" src="https://user-images.githubusercontent.com/1002748/99643613-c0a05900-2a01-11eb-8eeb-649d62822108.png">
