### PR TITLE
Fix spacing in Carousel

### DIFF
--- a/src/components/grid-aware/BlockQuoteBlock/BlockQuoteBlock.module.css
+++ b/src/components/grid-aware/BlockQuoteBlock/BlockQuoteBlock.module.css
@@ -41,6 +41,7 @@
 }
 
 .dots {
+  height: 20px;
   margin-top: 19px;
   text-align: center;
 }


### PR DESCRIPTION
Figma specifications:
<img width="206" alt="Screen Shot 2020-11-19 at 1 55 09 AM" src="https://user-images.githubusercontent.com/30575095/99650668-8ab3a280-2a0a-11eb-98ce-adaa66ac3f64.png">

<img width="122" alt="Screen Shot 2020-11-19 at 1 55 24 AM" src="https://user-images.githubusercontent.com/30575095/99650962-e2520e00-2a0a-11eb-9593-6daf75968a6e.png">

Corrrections: height becomes 20px
<img width="870" alt="Screen Shot 2020-11-19 at 1 55 37 AM" src="https://user-images.githubusercontent.com/30575095/99651069-01e93680-2a0b-11eb-9421-3bf71c9182cc.png">

Check on bottom grid, which has a 100px padding on its top:
<img width="591" alt="Screen Shot 2020-11-19 at 1 58 34 AM" src="https://user-images.githubusercontent.com/30575095/99651215-2513e600-2a0b-11eb-827e-d56fc0e6a1ea.png">




