### PR TITLE
1737 tweak image header

### DIFF
--- a/src/components/grid-aware/ImageHeader/ImageHeader.module.css
+++ b/src/components/grid-aware/ImageHeader/ImageHeader.module.css
@@ -64,6 +64,7 @@
   }
 
   .gridAreaImage2 {
+    margin-left: 22.67vw;
     text-align: right;
   }
 }


### PR DESCRIPTION
<img width="506" alt="Screen Shot 2020-11-19 at 4 59 35 AM" src="https://user-images.githubusercontent.com/30575095/99671139-767d9e80-2a26-11eb-9f03-af551da9385d.png">

I had to eyeball a decimal point of the viewport width but hope I did this right.