### PR TITLE
Hook up Mailchimp form footer

### DIFF
--- a/src/components/grid-aware/Footer/Footer.js
+++ b/src/components/grid-aware/Footer/Footer.js
@@ -12,8 +12,10 @@ import {
 import SubscriptionBlock from "./SubscriptionBlock";
 
 const Footer = ({
+  formAction,
+  formInputName,
   formInputPlaceholder,
-  formInputValue,
+  formAntiBotInputName,
   formDescription,
   footerNavigation,
   seals,
@@ -25,8 +27,10 @@ const Footer = ({
   return (
     <footer className={s.footer}>
       <SubscriptionBlock
+        formAction={formAction}
+        formInputName={formInputName}
         formInputPlaceholder={formInputPlaceholder}
-        formInputValue={formInputValue}
+        formAntiBotInputName={formAntiBotInputName}
         formDescription={formDescription}
       />
       <Navigation
@@ -44,20 +48,17 @@ const Footer = ({
 };
 
 Footer.propTypes = {
-  formInputPlaceholder: PropTypes.string,
-  formInputValue: PropTypes.string.isRequired,
-  formDescription: PropTypes.string,
+  formAction: PropTypes.string.isRequired,
+  formInputName: PropTypes.string.isRequired,
+  formInputPlaceholder: PropTypes.string.isRequired,
+  formAntiBotInputName: PropTypes.string.isRequired,
+  formDescription: PropTypes.string.isRequired,
   footerNavigation: PropTypes.arrayOf(FooterNavigationLinkPropType).isRequired,
   seals: PropTypes.arrayOf(SealPropType).isRequired,
   shelterTechLogo: ShelterTechLogoPropType.isRequired,
   socialMediaLinks: PropTypes.arrayOf(SocialMediaLinkPropType).isRequired,
   employerIdentificationNumber: PropTypes.string.isRequired,
   address: PropTypes.string.isRequired,
-};
-
-Footer.defaultProps = {
-  formInputPlaceholder: undefined,
-  formDescription: undefined,
 };
 
 export default Footer;

--- a/src/components/grid-aware/Footer/Footer.stories.js
+++ b/src/components/grid-aware/Footer/Footer.stories.js
@@ -13,8 +13,10 @@ export default {
 };
 
 const Template = ({
+  formAction,
   formInputPlaceholder,
-  formInputValue,
+  formInputName,
+  formAntiBotInputName,
   formDescription,
   footerNavigation,
   seals,
@@ -24,8 +26,10 @@ const Template = ({
   employerIdentificationNumber,
 }) => (
   <Footer
+    formAction={formAction}
     formInputPlaceholder={formInputPlaceholder}
-    formInputValue={formInputValue}
+    formInputName={formInputName}
+    formAntiBotInputName={formAntiBotInputName}
     formDescription={formDescription}
     footerNavigation={footerNavigation}
     seals={seals}
@@ -38,8 +42,11 @@ const Template = ({
 
 export const DefaultFooter = Template.bind({});
 DefaultFooter.args = {
+  formAction:
+    "https://sheltertech.us19.list-manage.com/subscribe/post?u=c47829732a0bea5c8e8a94604&amp;id=08f60e42ef",
   formInputPlaceholder: "email address",
-  formInputValue: "email",
+  formInputName: "EMAIL",
+  formAntiBotInputName: "b_c47829732a0bea5c8e8a94604_08f60e42ef",
   formDescription: "Subscribe to get updates",
   footerNavigation: [
     { text: "Programs", internalLink: "/new" },

--- a/src/components/grid-aware/Footer/SubscriptionBlock/SubscriptionBlock.js
+++ b/src/components/grid-aware/Footer/SubscriptionBlock/SubscriptionBlock.js
@@ -1,13 +1,15 @@
 import PropTypes from "prop-types";
 import React from "react";
-import Button from "../../../inline/Button";
+import { SubmitButton } from "../../../inline/Button";
 import InputText from "../../../inline/InputText";
 
 import s from "./SubscriptionBlock.module.css";
 
 const SubscriptionBlock = ({
+  formAction,
   formInputPlaceholder,
-  formInputValue,
+  formInputName,
+  formAntiBotInputName, // This is displayed as a text field but hidden from humans in order to trick bots into filling it out
   formDescription,
 }) => {
   return (
@@ -15,14 +17,26 @@ const SubscriptionBlock = ({
       <div className={s.subscriptionBlock}>
         <div className={s.subscribeContainer}>
           <div className={s.title}>{formDescription}</div>
-          <form className={s.form}>
+          <form
+            className={s.form}
+            action={formAction}
+            method="post"
+            target="_blank"
+          >
             <span className={s.inputText}>
               <InputText
+                name={formInputName}
                 placeholderText={formInputPlaceholder}
-                type={formInputValue}
+                type="email"
               />
             </span>
-            <Button text="submit" internalLink="/mailchimp" noHover />
+            <input
+              className={s.antiBotInput}
+              type="text"
+              aria-hidden
+              name={formAntiBotInputName}
+            />
+            <SubmitButton value="Subscribe" name="subscribe" noHover />
           </form>
         </div>
       </div>
@@ -31,14 +45,11 @@ const SubscriptionBlock = ({
 };
 
 SubscriptionBlock.propTypes = {
-  formInputPlaceholder: PropTypes.string,
-  formInputValue: PropTypes.string.isRequired,
-  formDescription: PropTypes.string,
-};
-
-SubscriptionBlock.defaultProps = {
-  formInputPlaceholder: undefined,
-  formDescription: undefined,
+  formAction: PropTypes.string.isRequired,
+  formInputName: PropTypes.string.isRequired,
+  formInputPlaceholder: PropTypes.string.isRequired,
+  formAntiBotInputName: PropTypes.string.isRequired,
+  formDescription: PropTypes.string.isRequired,
 };
 
 export default SubscriptionBlock;

--- a/src/components/grid-aware/Footer/SubscriptionBlock/SubscriptionBlock.module.css
+++ b/src/components/grid-aware/Footer/SubscriptionBlock/SubscriptionBlock.module.css
@@ -33,6 +33,13 @@
   width: 291px;
 }
 
+/* This appears to be a field that comes with the Mailchimp embed code to trick
+ * bots into filling it out, allowing them to differentiate bots from real
+ * users, who won't see this. */
+.antiBotInput {
+  display: none;
+}
+
 @media (--tablet-and-down) {
   .bleedWrapper {
     display: block;

--- a/src/components/inline/Button/Button.js
+++ b/src/components/inline/Button/Button.js
@@ -60,3 +60,21 @@ Button.propTypes = PropTypes.oneOfType([
 ]).isRequired;
 
 export default Button;
+
+/** A version of the Button specifically to be used with forms as the submit button. */
+export const SubmitButton = ({ value, noHover, name }) => {
+  const className = `${s.button} ${noHover ? s.noHover : ""}`;
+  return (
+    <input className={className} type="submit" name={name} value={value} />
+  );
+};
+
+SubmitButton.propTypes = {
+  value: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  noHover: PropTypes.bool,
+};
+
+SubmitButton.defaultProps = {
+  noHover: false,
+};

--- a/src/components/inline/Button/Button.stories.js
+++ b/src/components/inline/Button/Button.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import Button from "./Button";
+import Button, { SubmitButton } from "./Button";
 
 const demoStyling = {
   display: "flex",
@@ -47,4 +47,17 @@ OnClickButton.args = {
     // eslint-disable-next-line no-console
     console.log(`event is ${event}`);
   },
+};
+
+const SubmitTemplate = ({ name, value, noHover }) => (
+  <div style={demoStyling}>
+    <SubmitButton name={name} value={value} noHover={noHover} />
+  </div>
+);
+
+export const SubmitButtonStory = SubmitTemplate.bind({});
+SubmitButtonStory.args = {
+  name: "subscribe",
+  value: "Subscribe",
+  noHover: false,
 };

--- a/src/components/inline/Button/index.js
+++ b/src/components/inline/Button/index.js
@@ -1,1 +1,1 @@
-export { default } from "./Button";
+export { default, SubmitButton } from "./Button";

--- a/src/components/inline/InputText/InputText.js
+++ b/src/components/inline/InputText/InputText.js
@@ -24,11 +24,12 @@ import s from "./InputText.module.css";
  *
  */
 
-const InputText = ({ placeholderText, onChange, value, type }) => {
+const InputText = ({ name, placeholderText, onChange, value, type }) => {
   return (
     <input
       className={s.inputText}
       type={type}
+      name={name}
       placeholder={placeholderText}
       onChange={onChange}
       value={value}
@@ -37,6 +38,7 @@ const InputText = ({ placeholderText, onChange, value, type }) => {
 };
 
 InputText.propTypes = {
+  name: PropTypes.string,
   placeholderText: PropTypes.string,
   onChange: PropTypes.func,
   value: PropTypes.string,
@@ -44,6 +46,7 @@ InputText.propTypes = {
 };
 
 InputText.defaultProps = {
+  name: undefined,
   placeholderText: undefined,
   onChange: undefined,
   value: undefined,

--- a/src/components/inline/InputText/InputText.stories.js
+++ b/src/components/inline/InputText/InputText.stories.js
@@ -15,7 +15,7 @@ export default {
   component: InputText,
 };
 
-const Template = ({ placeholderText, type }) => {
+const Template = ({ placeholderText, type, name }) => {
   const [value, setValue] = useState("");
 
   const handleChange = (e) => {
@@ -26,6 +26,7 @@ const Template = ({ placeholderText, type }) => {
     <span style={demoStyling}>
       <InputText
         type={type}
+        name={name}
         placeholderText={placeholderText}
         onChange={handleChange}
         value={value}
@@ -38,4 +39,5 @@ export const DefaultInputText = Template.bind({});
 DefaultInputText.args = {
   placeholderText: "email address",
   type: "email",
+  name: "foo",
 };

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -42,8 +42,10 @@ const Layout = ({ children }) => {
         />
         {children}
         <Footer
+          formAction="https://sheltertech.us19.list-manage.com/subscribe/post?u=c47829732a0bea5c8e8a94604&amp;id=08f60e42ef"
+          formInputName="EMAIL"
           formInputPlaceholder="email address"
-          formInputValue="email"
+          formAntiBotInputName="b_c47829732a0bea5c8e8a94604_08f60e42ef"
           formDescription="Subscribe to get updates"
           footerNavigation={[
             { text: "Programs", internalLink: "/new" },


### PR DESCRIPTION
I had to make some tweaks to the form in the footer to get the Mailchimp form to work. To make things simpler, I decided to leave the form as an uncontrolled component so that when you click the submit button, it submits it like a vanilla HTML form rather than trying to handle all of it in React. This made it easier to port the embedded HTML snippet that Mailchimp provides us, especially because there's also a hidden field that they use to detect bots that just randomly fill out all fields.

I also created a new variant of the `<Button>` component to use the `<input type="submit">` element type, since that is needed to submit a vanilla form, and a `<button>` or an `<a>` tag don't work here.

I noticed something that's a little bit weird with the actual form you end up on in Mailchimp, and I think there's a chance that we have the wrong embed code. I let Derek and Chelsea know that I think we may have the wrong code, but it should be quick to fix up later, even if we merge this now, since all it takes is for us to update a few fields.