### PR TITLE
Fix padding for input

### DIFF
--- a/src/components/inline/InputText/InputText.module.css
+++ b/src/components/inline/InputText/InputText.module.css
@@ -2,6 +2,6 @@
   border: 1px solid var(--color-gray-400);
   box-sizing: border-box;
   font: var(--font-body-small);
-  padding: 16px 16px 15px 17px;
+  padding: 17px 16px 16px 17px;
   width: 100%;
 }


### PR DESCRIPTION
Since there is a 1px border in the input, minused from 2px originally. Ive increased the top and bottom padding by 1px.
<img width="350" alt="Screen Shot 2020-11-20 at 12 40 31 AM" src="https://user-images.githubusercontent.com/30575095/99779147-7e424f00-2ac9-11eb-9869-f17c38a2abdd.png">
<img width="574" alt="Screen Shot 2020-11-20 at 12 40 24 AM" src="https://user-images.githubusercontent.com/30575095/99779149-7edae580-2ac9-11eb-95fc-663e9352b15d.png">

