### PR TITLE
Add bottom border to Navigation.

### DIFF
--- a/src/components/grid-aware/Navigation/Navigation.module.css
+++ b/src/components/grid-aware/Navigation/Navigation.module.css
@@ -14,6 +14,7 @@
 
 @media (--tablet-and-down) {
   .bleedWrapper {
+    border-bottom: 1px solid var(--color-gray-400);
     grid-template-columns: 20px 1fr 20px;
   }
 }
@@ -23,6 +24,7 @@
 
 .container {
   align-items: center;
+  border-bottom: 1px solid var(--color-gray-400);
   display: flex;
   grid-column: 2;
   height: 130px;
@@ -33,6 +35,7 @@
 
 @media (--tablet-and-down) {
   .container {
+    border-bottom: 0;
     height: 90px;
     padding-left: 0;
     padding-right: 0;


### PR DESCRIPTION
I had missed this when first implementing the top navigation menu, probably because you can't even really see this on the Home page, due to the hero unit. It's a bit more obvious on the Volunteer page, which has a hero that has a white background.

Now the nav should match the designs:

<img width="373" alt="Screen Shot 2020-11-20 at 12 42 08 AM" src="https://user-images.githubusercontent.com/1002748/99779187-8bf7d480-2ac9-11eb-8a4b-b1c859b985f9.png">
<img width="1356" alt="Screen Shot 2020-11-20 at 12 42 23 AM" src="https://user-images.githubusercontent.com/1002748/99779193-8ef2c500-2ac9-11eb-90d9-54e447c58dcd.png">
