### PR TITLE
Grid fixups

### DIFF
--- a/src/components/grid-aware/ArticleSpotlightCard/ArticleSpotlightCard.module.css
+++ b/src/components/grid-aware/ArticleSpotlightCard/ArticleSpotlightCard.module.css
@@ -1,9 +1,9 @@
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   grid-template-rows: 600px;
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .bleedBackground {

--- a/src/components/grid-aware/ArticleSpotlightCard/ArticleSpotlightCard.module.css
+++ b/src/components/grid-aware/ArticleSpotlightCard/ArticleSpotlightCard.module.css
@@ -6,6 +6,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedBackground {
   grid-column: 2 / span 2;
   grid-row: 1;
@@ -14,8 +19,6 @@
 .bleedMainContent {
   grid-column: 2;
   grid-row: 1;
-  /* Override grid item default of auto so that item contents cannot stretch the grid itself */
-  min-width: 0;
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/BlockQuoteBlock/BlockQuoteBlock.module.css
+++ b/src/components/grid-aware/BlockQuoteBlock/BlockQuoteBlock.module.css
@@ -5,6 +5,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 @media (--tablet-and-down) {
   .bleedWrapper {
     display: block;

--- a/src/components/grid-aware/BlockQuoteBlock/BlockQuoteBlock.module.css
+++ b/src/components/grid-aware/BlockQuoteBlock/BlockQuoteBlock.module.css
@@ -1,8 +1,8 @@
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/COVID19InfoBoxBlock/COVID19InfoBoxBlock.module.css
+++ b/src/components/grid-aware/COVID19InfoBoxBlock/COVID19InfoBoxBlock.module.css
@@ -5,6 +5,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedMainContent {
   background: var(--color-gray-300);
   grid-column: 2;

--- a/src/components/grid-aware/COVID19InfoBoxBlock/COVID19InfoBoxBlock.module.css
+++ b/src/components/grid-aware/COVID19InfoBoxBlock/COVID19InfoBoxBlock.module.css
@@ -1,8 +1,8 @@
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .bleedMainContent {

--- a/src/components/grid-aware/DonationBlock/DonationBlock.module.css
+++ b/src/components/grid-aware/DonationBlock/DonationBlock.module.css
@@ -7,6 +7,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 @media (--tablet-and-down) {
   .bleedWrapper {
     display: block;

--- a/src/components/grid-aware/DonationBlock/DonationBlock.module.css
+++ b/src/components/grid-aware/DonationBlock/DonationBlock.module.css
@@ -2,9 +2,9 @@
 
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: 60px auto 120px;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/Footer/InfoBlock/InfoBlock.module.css
+++ b/src/components/grid-aware/Footer/InfoBlock/InfoBlock.module.css
@@ -8,6 +8,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .organizationInfo {
   display: flex;
   justify-content: space-between;

--- a/src/components/grid-aware/Footer/InfoBlock/InfoBlock.module.css
+++ b/src/components/grid-aware/Footer/InfoBlock/InfoBlock.module.css
@@ -5,7 +5,7 @@
   color: var(--color-gray-400);
   font: var(--font-body-small);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .organizationInfo {

--- a/src/components/grid-aware/Footer/NavigationBlock/NavigationBlock.module.css
+++ b/src/components/grid-aware/Footer/NavigationBlock/NavigationBlock.module.css
@@ -6,6 +6,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .gridParent {
   display: flex;
   flex-direction: row;

--- a/src/components/grid-aware/Footer/NavigationBlock/NavigationBlock.module.css
+++ b/src/components/grid-aware/Footer/NavigationBlock/NavigationBlock.module.css
@@ -1,9 +1,9 @@
 .bleedWrapper {
   background-color: var(--color-deep-blue);
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .gridParent {

--- a/src/components/grid-aware/Footer/SubscriptionBlock/SubscriptionBlock.module.css
+++ b/src/components/grid-aware/Footer/SubscriptionBlock/SubscriptionBlock.module.css
@@ -2,7 +2,7 @@
 
 .bleedWrapper {
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 /* Top Row */

--- a/src/components/grid-aware/HomePageLargeParagraph/HomePageLargeParagraph.module.css
+++ b/src/components/grid-aware/HomePageLargeParagraph/HomePageLargeParagraph.module.css
@@ -1,9 +1,9 @@
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   justify-items: center;
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
   padding-bottom: 120px;
   padding-top: 120px;
 }

--- a/src/components/grid-aware/HomePageLargeParagraph/HomePageLargeParagraph.module.css
+++ b/src/components/grid-aware/HomePageLargeParagraph/HomePageLargeParagraph.module.css
@@ -8,11 +8,14 @@
   padding-top: 120px;
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedMainContent {
   grid-column: 2;
   grid-row: 1;
-  /* Override grid item default of auto so that item contents cannot stretch the grid itself */
-  min-width: 0;
   text-align: center;
 }
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/ImageHeader/ImageHeader.module.css
+++ b/src/components/grid-aware/ImageHeader/ImageHeader.module.css
@@ -2,9 +2,9 @@
 
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .bleedMainContent {

--- a/src/components/grid-aware/ImageHeader/ImageHeader.module.css
+++ b/src/components/grid-aware/ImageHeader/ImageHeader.module.css
@@ -7,9 +7,13 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedMainContent {
   grid-column: 2;
-  min-width: 0;
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/Navigation/Navigation.module.css
+++ b/src/components/grid-aware/Navigation/Navigation.module.css
@@ -2,9 +2,9 @@
 
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .bleedWrapper > * {

--- a/src/components/grid-aware/OneParagraphBlock/OneParagraphBlock.module.css
+++ b/src/components/grid-aware/OneParagraphBlock/OneParagraphBlock.module.css
@@ -2,9 +2,9 @@
 
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .bleedBackground {

--- a/src/components/grid-aware/OneParagraphBlock/OneParagraphBlock.module.css
+++ b/src/components/grid-aware/OneParagraphBlock/OneParagraphBlock.module.css
@@ -7,6 +7,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedBackground {
   background: var(--color-black);
   grid-column: 2 / span 2;
@@ -16,7 +21,6 @@
 .bleedMainContent {
   grid-column: 2;
   grid-row: 1;
-  min-width: 0;
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/PartnersAndSponsorsBlock/PartnersAndSponsorsBlock.module.css
+++ b/src/components/grid-aware/PartnersAndSponsorsBlock/PartnersAndSponsorsBlock.module.css
@@ -6,6 +6,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 @media (--tablet-and-down) {
   .bleedWrapper {
     grid-template-columns: 40px 1fr 40px;

--- a/src/components/grid-aware/PartnersAndSponsorsBlock/PartnersAndSponsorsBlock.module.css
+++ b/src/components/grid-aware/PartnersAndSponsorsBlock/PartnersAndSponsorsBlock.module.css
@@ -1,9 +1,9 @@
 /* Outer Grid */
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/ProgramsBlock/ProgramsBlock.module.css
+++ b/src/components/grid-aware/ProgramsBlock/ProgramsBlock.module.css
@@ -2,9 +2,9 @@
 .bleedWrapper {
   background: var(--color-black);
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/ProgramsBlock/ProgramsBlock.module.css
+++ b/src/components/grid-aware/ProgramsBlock/ProgramsBlock.module.css
@@ -7,6 +7,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 @media (--tablet-and-down) {
   .bleedWrapper {
     grid-template-columns: 20px 1fr 20px;

--- a/src/components/grid-aware/Spacer/Spacer.module.css
+++ b/src/components/grid-aware/Spacer/Spacer.module.css
@@ -2,7 +2,7 @@
   background-color: var(--spacer-color);
   height: var(--spacer-height-desktop);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/StatsBlock/StatsBlock.module.css
+++ b/src/components/grid-aware/StatsBlock/StatsBlock.module.css
@@ -5,6 +5,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedBackground {
   background-color: var(--color-black);
   grid-column: 2 / span 2;
@@ -14,8 +19,6 @@
 .bleedMainContent {
   grid-column: 2;
   grid-row: 1;
-  /* Override grid item default of auto so that item contents cannot stretch the grid itself */
-  min-width: 0;
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/StatsBlock/StatsBlock.module.css
+++ b/src/components/grid-aware/StatsBlock/StatsBlock.module.css
@@ -1,8 +1,8 @@
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .bleedBackground {

--- a/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.module.css
+++ b/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.module.css
@@ -26,10 +26,10 @@
 
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   grid-template-rows: auto 0;
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
   overflow-x: hidden;
 }
 

--- a/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.module.css
+++ b/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.module.css
@@ -33,6 +33,11 @@
   overflow-x: hidden;
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedBackground {
   background: var(--color-gray-300);
   grid-column: 1 / span 2;
@@ -42,8 +47,6 @@
 .bleedMainContent {
   grid-column: 2;
   grid-row: 1;
-  /* Override grid item default of auto so that item contents cannot stretch the grid itself */
-  min-width: 0;
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/TitleBlock/TitleBlock.module.css
+++ b/src/components/grid-aware/TitleBlock/TitleBlock.module.css
@@ -7,11 +7,14 @@
   padding-top: 120px;
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedMainContent {
   grid-column: 2;
   grid-row: 1;
-  /* Override grid item default of auto so that item contents cannot stretch the grid itself */
-  min-width: 0;
 }
 @media (--tablet-and-down) {
   .bleedWrapper {

--- a/src/components/grid-aware/TitleBlock/TitleBlock.module.css
+++ b/src/components/grid-aware/TitleBlock/TitleBlock.module.css
@@ -1,8 +1,8 @@
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
   padding-bottom: 40px;
   padding-top: 120px;
 }

--- a/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
+++ b/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
@@ -7,6 +7,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedBackground {
   background: var(--color-gray-300);
   grid-column: 1 / span 2;
@@ -16,7 +21,6 @@
 .bleedMainContent {
   grid-column: 2;
   grid-row: 1;
-  min-width: 0;
 }
 
 @media (--tablet-and-down) {

--- a/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
+++ b/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
@@ -2,9 +2,9 @@
 
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .bleedBackground {

--- a/src/components/grid-aware/VideoHeader/VideoHeader.module.css
+++ b/src/components/grid-aware/VideoHeader/VideoHeader.module.css
@@ -7,6 +7,11 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .bleedBackground {
   /* The --background-image CSS variable should be set as an inline style on the element */
   background:
@@ -14,15 +19,11 @@
     center / cover var(--background-image);
   grid-column: 1 / span 3;
   grid-row: 1;
-  /* Override grid item default of auto so that item contents cannot stretch the grid itself */
-  min-width: 0;
 }
 
 .bleedMainContent {
   grid-column: 2;
   grid-row: 1;
-  /* Override grid item default of auto so that item contents cannot stretch the grid itself */
-  min-width: 0;
 }
 
 

--- a/src/components/grid-aware/VideoHeader/VideoHeader.module.css
+++ b/src/components/grid-aware/VideoHeader/VideoHeader.module.css
@@ -2,9 +2,9 @@
 
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   margin: auto;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .bleedBackground {

--- a/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.module.css
+++ b/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.module.css
@@ -6,14 +6,17 @@
   max-width: var(--bleed-max-width);
 }
 
+/* Override grid item default of auto so that item contents cannot stretch the grid itself */
+.bleedWrapper > * {
+  min-width: 0;
+}
+
 .blackBackground {
   background-color: var(--color-black);
 }
 
 .bleedMainContent {
   grid-column: 2;
-  /* Override grid item default of auto so that item contents cannot stretch the grid itself */
-  min-width: 0;
 }
 
 .gridParent {

--- a/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.module.css
+++ b/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.module.css
@@ -1,9 +1,9 @@
 .bleedWrapper {
   display: grid;
-  grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  grid-template-columns: var(--bleed-grid-template-columns);
   grid-template-rows: 465px;
   margin: 0 auto 42px;
-  max-width: var(--grid-bleed-max-width);
+  max-width: var(--bleed-max-width);
 }
 
 .blackBackground {

--- a/src/stylesheets/global.css
+++ b/src/stylesheets/global.css
@@ -64,9 +64,10 @@
   /* Grid */
   --grid-column-count: 12;
   --grid-column-gap: 30px;
-  --grid-bleed-max-width: 1440px;
   --grid-content-max-width: 1290px;
   --grid-content-min-width: 1024px;
+  --bleed-max-width: 1440px;
+  --bleed-grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
 }
 
 @media (--phone-and-down) {

--- a/src/stylesheets/global.css
+++ b/src/stylesheets/global.css
@@ -64,10 +64,11 @@
   /* Grid */
   --grid-column-count: 12;
   --grid-column-gap: 30px;
-  --grid-content-max-width: 1290px;
-  --grid-content-min-width: 1024px;
   --bleed-max-width: 1440px;
-  --bleed-grid-template-columns: 1fr minmax(var(--grid-content-min-width), var(--grid-content-max-width)) 1fr;
+  --bleed-grid-template-columns:
+    minmax(40px, 1fr)
+    minmax(0, 1290px)
+    minmax(40px, 1fr);
 }
 
 @media (--phone-and-down) {


### PR DESCRIPTION
This mitigates the issues described in https://app.clubhouse.io/sheltertech/story/1758/fix-up-outer-grid-spacing-issues

I set a minimum amount of spacing on the sides of the outer grid, and I also refactored all of the grid-aware components to use a single definition of the `grid-template-columns` in the form of a shared, global variable.

I also did a bit of refactoring of the grid blowout protection by moving the `min-width: 0` out of the individual child elements and into a universal child selector based on the `.bleedWrapper`, which makes it more uniform.

I attempted to fix the overflow issue, but I unfortunately discovered that there's an issue with trying to universally apply `overflow-x: hidden` to all `.bleedWrappers`. Apparently, if you apply a non-`visible` overflow value to one dimension, then the other dimension may get `overflow: auto` set by default: https://stackoverflow.com/a/6433475

I can't really find an explanation as to why this is the case, other than for historical reasons, but this means that it is inherently incompatible with any of our components that intentionally have an image hanging over the bottom of the component's bounding box. This causes the vertical overflow to be invisible, and instead for the area to be scrollable in the vertical direction, which is definitely not what we're going for.