### PR TITLE
Refactor VideoSpotlightBlock to not use z-index.

### DIFF
--- a/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.js
+++ b/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.js
@@ -4,13 +4,6 @@ import Button from "../../inline/Button";
 import playIcon from "./PlayIcon.svg";
 import s from "./VideoSpotlightBlock.module.css";
 
-/* PropType shapes */
-
-const ImagePropType = PropTypes.shape({
-  url: PropTypes.string.isRequired,
-  alt: PropTypes.string.isRequired,
-});
-
 const TextCard = ({ eyebrowText, description, button }) => (
   <div className={s.textCard}>
     <div className={s.eyebrowText}>{eyebrowText}</div>
@@ -36,7 +29,7 @@ const VideoSpotlightBlock = ({
   eyebrowText,
   description,
   button,
-  image,
+  imageURL,
   playButtonLink,
   blackBackground,
 }) => {
@@ -46,13 +39,17 @@ const VideoSpotlightBlock = ({
 
   return (
     <div className={bleedBackgroundWrapper}>
-      <div className={s.bleedImage}>
-        <div className={s.playButton}>
-          <a rel="noreferrer" href={playButtonLink} target="_blank">
-            <img className={s.playIcon} src={playIcon} alt="Play Video" />
-          </a>
+      <div className={s.bleedImageWrapper}>
+        <div
+          className={s.bleedImage}
+          style={{ "--background-image": `url(${imageURL})` }}
+        >
+          <div className={s.playButton}>
+            <a rel="noreferrer" href={playButtonLink} target="_blank">
+              <img className={s.playIcon} src={playIcon} alt="Play Video" />
+            </a>
+          </div>
         </div>
-        <img className={s.image} src={image.url} alt={image.alt} />
       </div>
       <div className={s.bleedMainContent}>
         <div className={s.gridParent}>
@@ -75,7 +72,7 @@ VideoSpotlightBlock.propTypes = {
   eyebrowText: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   button: PropTypes.shape(Button.propTypes).isRequired,
-  image: ImagePropType.isRequired,
+  imageURL: PropTypes.string.isRequired,
   playButtonLink: PropTypes.string.isRequired,
   blackBackground: PropTypes.bool,
 };

--- a/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.module.css
+++ b/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.module.css
@@ -41,16 +41,19 @@
 }
 
 /* Relating to .bleedImage */
-.playButton {
-  left: 50%;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
+.bleedImage {
+  align-items: center;
+  background: center / contain no-repeat var(--background-image);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
 }
 
 @media (--laptop-and-up) {
-  .bleedImage {
-    position: absolute;
+  .bleedImageWrapper {
+    height: 505px;
+    width: 900px;
   }
 
   .playIcon {
@@ -60,13 +63,19 @@
 }
 
 @media (--tablet-and-down) {
-  .bleedImage {
+  /* Use a trick with bottom padding to allow for responsive elements that
+   * preserve  aspect ratio.
+   *
+   * https://fettblog.eu/blog/2013/06/16/preserving-aspect-ratio-for-embedded-iframes/
+   */
+  .bleedImageWrapper {
+    max-width: 100%;
+    padding-bottom: 56.25%; /* 9/16 for a 16:9 aspect ratio */
     position: relative;
   }
 
-  .image {
-    display: block;
-    max-width: 100%;
+  .bleedImage {
+    position: absolute;
   }
 }
 
@@ -99,7 +108,6 @@
 @media (--laptop-and-up) {
   .gridAreaCard {
     grid-column: 8 / span 5;
-    z-index: 1;
   }
 
   .textCardWrapper {

--- a/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.stories.js
+++ b/src/components/grid-aware/VideoSpotlightBlock/VideoSpotlightBlock.stories.js
@@ -12,7 +12,7 @@ const Template = ({
   eyebrowText,
   description,
   button,
-  image,
+  imageURL,
   playButtonLink,
   blackBackground,
 }) => (
@@ -20,7 +20,7 @@ const Template = ({
     eyebrowText={eyebrowText}
     description={description}
     button={button}
-    image={image}
+    imageURL={imageURL}
     playButtonLink={playButtonLink}
     blackBackground={blackBackground}
   />
@@ -32,10 +32,7 @@ VideoSpotlightBlockDefault.args = {
   description:
     "Over 3,000 people have daily internet access in local shelters and resource centers.",
   button: { text: "View Annual Report", internalLink: "/foo" },
-  image: {
-    url: videoSpotlightBlockImage,
-    alt: "Video spotlight of Aaron speaking.",
-  },
+  imageURL: videoSpotlightBlockImage,
   playButtonLink: "/foo",
 };
 
@@ -45,10 +42,7 @@ VideoSpotlightBlockBlackBackground.args = {
   description:
     "Over 3,000 people have daily internet access in local shelters and resource centers.",
   button: { text: "View Annual Report", internalLink: "/foo" },
-  image: {
-    url: videoSpotlightBlockImage,
-    alt: "Video spotlight of Aaron speaking.",
-  },
+  imageURL: videoSpotlightBlockImage,
   playButtonLink: "/foo",
   blackBackground: true,
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -130,10 +130,7 @@ export default () => {
         eyebrowText="Our Impact"
         description="Over 3,000 people have daily internet access in local shelters and resource centers."
         button={{ text: "View Annual Report", externalLink: annualReportPDF }}
-        image={{
-          url: videoSpotlightBlockImage,
-          alt: "Video spotlight of Aaron speaking.",
-        }}
+        imageURL={videoSpotlightBlockImage}
         playButtonLink="https://www.youtube.com/watch?v=2aLyGwaRufY"
         blackBackground
       />


### PR DESCRIPTION
While working on the embedded video modals, I hit an issue due to the `z-index: 1` that we had on this component, where the card would be on top of the modal. This PR changes the VideoSpotlightBlock to not rely on `z-index`, which makes it more self-contained. I decided to split this out into its own PR first, since it seemed substantial and standalone enough to warrant splitting off into its own change.

This makes use of a trick described in https://fettblog.eu/blog/2013/06/16/preserving-aspect-ratio-for-embedded-iframes/ to allow for responsive elements that preserve the aspect ratio.

This PR makes a few structural changes to the component:

- The `<img>` element has been removed, and instead we now set the image as a background image of the `.bleedImage` element.
- There is a new `.bleedImageWrapper` element that sits between the `.bleedWrapper` and the `.bleedImage` elements. This element has different behavior in desktop and mobile, but in both cases, it is there to help with positioning of the `.bleedImage`.
- `.bleedImage` now uses flexbox to center the play button icon.