### PR TITLE
Add flex to all statCard child components and add 0 margin-right to t…

### DIFF
--- a/src/components/grid-aware/StatsBlock/StatsBlock.module.css
+++ b/src/components/grid-aware/StatsBlock/StatsBlock.module.css
@@ -73,8 +73,13 @@
 }
 
 .statCard {
+  flex: 1 1 0;
   margin-right: 110px;
   width: 250px;
+}
+
+.statCard:last-child {
+  margin-right: 0;
 }
 
 @media (--tablet-and-down) {
@@ -92,6 +97,7 @@
   font-size: 72px;
   font-weight: bold;
   line-height: 1.3;
+  min-width: 100px;
 }
 
 .statement {

--- a/src/components/grid-aware/StatsBlock/StatsBlock.module.css
+++ b/src/components/grid-aware/StatsBlock/StatsBlock.module.css
@@ -97,7 +97,6 @@
   font-size: 72px;
   font-weight: bold;
   line-height: 1.3;
-  min-width: 100px;
 }
 
 .statement {
@@ -111,4 +110,3 @@
     line-height: 1.3;
   }
 }
-


### PR DESCRIPTION
Add shorthand flex to the child components statCard to evenly distribute the basis(default size of an element before the remaining space is distributed), shrink(the ability for flex item to shrink if necessary), and grow(the ability for flex item to grow if necessary).

Add 0 to margin-right for the last child statCard to take away the spacing.