### PR TITLE
Touch up CSS to improve ThreeParagraphBlock at 1024px.

### DIFF
--- a/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.module.css
+++ b/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.module.css
@@ -133,6 +133,7 @@
 
 .leftBottomImageWrapper {
   left: 30px;
+  margin-right: 60px; /* Ensure minimum spacing from the middle grid area. */
   position: relative;
 }
 

--- a/src/components/inline/Button/Button.module.css
+++ b/src/components/inline/Button/Button.module.css
@@ -8,6 +8,7 @@
   line-height: 1.5;
   outline: none;
   padding: 16px 40px;
+  text-align: center;
   text-decoration: none;
   text-transform: uppercase;
 }


### PR DESCRIPTION
This tries to improve the ThreeParagraphBlock when viewed at 1024px.

There's really just two changes I made:

- I set a margin-right on the image on the left side to ensure that there is always some distance separating it from the other paragraphs
- I updated the Button component to center-align its text. I couldn't actually figure out a way to make the button narrower when it wraps. It just looks like when an inline-block element wraps, then it just takes up the full width of its parent. The best I think I can do here is just center-align the button text.

## Before

<img width="1024" alt="Screen Shot 2020-11-23 at 7 30 57 PM" src="https://user-images.githubusercontent.com/1002748/100043544-80a2f280-2dc2-11eb-96a1-2bd90a6fb8e4.png">

## After

<img width="1021" alt="Screen Shot 2020-11-23 at 7 30 30 PM" src="https://user-images.githubusercontent.com/1002748/100043552-839de300-2dc2-11eb-9939-58e83831a504.png">
