### PR TITLE
Use embed versions of the video URLs.

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -55,7 +55,7 @@ export default () => {
         noBezel
       >
         <YouTubeEmbed
-          url="https://www.youtube.com/watch?v=V1u2l_8C75k"
+          url="https://www.youtube.com/embed/V1u2l_8C75k"
           title="Accelerating digital inclusion for people experiencing homelessness"
         />
       </Modal>
@@ -66,7 +66,7 @@ export default () => {
         noBezel
       >
         <YouTubeEmbed
-          url="https://www.youtube.com/watch?v=AUAGqr8Uf_o"
+          url="https://www.youtube.com/embed/AUAGqr8Uf_o"
           title="ShelterTech in 2020"
         />
       </Modal>


### PR DESCRIPTION
Sorry, I should have reviewed https://github.com/ShelterTechSF/sheltertech.org/pull/131 a bit more carefully. The URLs entered in there don't work for embedding, which is causing the site to show this when you try to open a video:

<img width="1034" alt="Screen Shot 2020-11-23 at 9 44 47 PM" src="https://user-images.githubusercontent.com/1002748/100053583-32e3b580-2dd5-11eb-94ab-948d04192582.png">

This updates both video URLs on the home page to use the embed versions, which allows it to embed properly:

<img width="1297" alt="Screen Shot 2020-11-23 at 9 45 51 PM" src="https://user-images.githubusercontent.com/1002748/100053619-4727b280-2dd5-11eb-85f0-6374ab6c4523.png">
