### PR TITLE
Update Article Spotlight on Volunteer Page with final link.

### DIFF
--- a/src/pages/volunteer/index.js
+++ b/src/pages/volunteer/index.js
@@ -189,7 +189,8 @@ export default () => {
         description="I moved to San Francisco in 2019 and immediately decided to join ShelterTech as I felt compelled to take action to address the worsening homelessness crisis. As Product Lead, I have focused on managing product development and on improving collaboration across all key teams to ensure we build an impactful product."
         button={{
           text: "Read More",
-          externalLink: "/foo",
+          externalLink:
+            "https://medium.com/shelter-tech/volunteer-spotlight-laura-barrera-vera-41594cfbbe7b",
         }}
         backgroundImage={articleSpotlightImage}
       />


### PR DESCRIPTION
We got the Volunteer Spotlight blog post up, so now we can update this component at the bottom of the Volunteer page with the real link.