### PR TITLE
Add workflow for pushing Storybook to gh-pages

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,37 @@
+name: Deploy Storybook
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  deploy:
+    name: Deploy Storybook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Checkout GitHub Pages branch
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions@github.com"
+          git checkout -B gh-pages
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Push Storybook to GitHub Pages branch
+        run: |
+          git add storybook-static
+          git commit -m "Build Storybook (auto-generated commit)"
+          git push --set-upstream origin gh-pages --force

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -15,6 +15,13 @@ jobs:
         with:
           node-version: '14'
 
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Checkout GitHub Pages branch
         run: |
           git config user.name "GitHub Actions"

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
           node-version: '14'
 

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -38,4 +38,4 @@ jobs:
         run: |
           git add storybook-static
           git commit -m "Build Storybook (auto-generated commit)"
-          git push --set-upstream origin gh-pages --force
+          git push origin gh-pages --force

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -15,9 +15,6 @@ jobs:
         with:
           node-version: '14'
 
-      - name: Install dependencies
-        run: npm install
-
       - name: Checkout GitHub Pages branch
         run: |
           git config user.name "GitHub Actions"


### PR DESCRIPTION
## Description

This PR adds a [Github Actions workflow](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions) that should do the following:

- Whenever we merge to `main`, this workflow gets triggered
- The workflow builds Storybook and pushes the resulting `storybook-static` directory to the `gh-pages` branch
- Once pushed, we should be able to view Storybook live at a url with the pattern `http(s)://<organization>.github.io/<repository>/storybook-static` (so in our case, I think it would be `https://ShelterTechSF.github.io/sheltertech.org/storybook-static` ?)

Resolves #152.
## Testing
Due to the nature of GitHub Action workflows, it's impossible for me to completely test this prior to merging. However, I did decide to try setting up a similar workflow on one of my own repos. The total steps were slightly different (it has a more annoying npm setup stage), but the steps for building Storybook and pushing to GitHub Pages are the same, and they worked just fine. 

Once this is live, we'll want to make sure the following cases are true:
- The workflow triggers whenever we merge into `main`
- The workflow doesn't fail (unless it's because we clearly broke something unrelated)
- The `gh-pages` branch gets an automated commit containing the contents of `storybook-static`
- The `gh-pages` branch is otherwise up to date with `main`
- The GitHub Pages url shows Storybook the same way it does when we view it locally

## Other Notes

- When I did this on my personal repo, I had to enable GitHub Pages in my repository settings. I don't have access to the settings for this repo, so that part is up to @richardxia. The settings page is also where we can definitively see what the url for GitHub Pages is.

- The workflow checks out the `gh-pages` branch using `git checkout -B`, which isn't an operation that I've used before this, but here's my understanding of it:

    - `git checkout -B` does the same operation as `git branch --force`, which effectively resets the branch as if it's newly branched from `main`. Also, if the branch doesn't already exist, it creates a new one much like the `-b` flag. If this description sounds wrong, feel free to school me on this!
 
    - For our purposes this means it always uses the latest `main` without doing any merging or rebasing (a plus in my eyes), but it also means we won't keep old commits performed by this workflow (I am neutral about this, since they're auto-generated anyway, and we still have revision history for the actual source files)
 
    - I'm sure it's possible to set up this workflow such that we could avoid `git checkout -B`, but from my brief tinkering with it, it would add some extra complexity that I'm not sure we need right now. But if we ever want to do other things with the `gh-pages` branch, we will probably need to change this behavior.



