### PR TITLE
Add storybook info and url to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ For more specific documentation, visit one of the pages below:
 
 To view the current state of any new features the staging website, please visit
 https://staging.sheltertech.org/.
+
+## Storybook component library
+
+We use GitHub pages to host a live version of [Storybook](https://storybook.js.org/), our component library. Using GitHub Actions, it is automatically kept in sync with the `main` branch. It can be found at http://sheltertechsf.github.io/sheltertech.org/storybook-static.


### PR DESCRIPTION
Updates the readme with a link to the GitHub Pages deployment of Storybook that is now automatically pushed via a GitHub Action. (I would've just done this as part of my last PR but I wanted to be certain this was the correct url 🤷‍♀️ )

Resolves #156