### PR TITLE
Add storybook-static dir to .gitignore.

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Push Storybook to GitHub Pages branch
         run: |
-          git add storybook-static
+          # The --force is necessary because storybook-static is normally
+          # .gitignore'd
+          git add --force storybook-static
           git commit -m "Build Storybook (auto-generated commit)"
           git push origin gh-pages --force

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ jspm_packages/
 # gatsby files
 .cache/
 public
+
+# Storybook files
+/storybook-static


### PR DESCRIPTION
This adds the `storybook-static/` directory to .gitignore so that we don't accidentally commit it during normal development.

Note that I had to make a small modification (https://github.com/ShelterTechSF/sheltertech.org/commit/5fc4c0038a830dae2b6fcd3af211c49df5fda3d4) to @jessypeck's GitHub Action for building and deploying Storybook, since the `git add` command now needs the `--force` flag to tell it to add the directory, even though would normally be ignored. I didn't test that, but I tested the `git add --force` command locally to check that it will add the `storybook-static/` files.