### PR TITLE
Convert Mailchimp forms to TypeScript.

### DIFF
--- a/src/components/thirdparty/mailchimp/BaseForm/BaseForm.tsx
+++ b/src/components/thirdparty/mailchimp/BaseForm/BaseForm.tsx
@@ -1,5 +1,4 @@
-import PropTypes from "prop-types";
-import React from "react";
+import * as React from "react";
 
 import "./globals.css";
 import s from "./BaseForm.module.css";
@@ -7,18 +6,17 @@ import s from "./BaseForm.module.css";
 /* eslint-disable react/no-danger */
 // This entire file is just about embedding an external form
 
-const BaseForm = ({ title, description, rawFormHTML }) => (
+type BaseFormProps = {
+  title: string;
+  description: string;
+  rawFormHTML: string;
+};
+const BaseForm = ({ title, description, rawFormHTML }: BaseFormProps) => (
   <div>
     <h1 className={s.title}>{title}</h1>
     <p className={s.description}>{description}</p>
     <div dangerouslySetInnerHTML={{ __html: rawFormHTML }} />
   </div>
 );
-
-BaseForm.propTypes = {
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
-  rawFormHTML: PropTypes.string.isRequired,
-};
 
 export default BaseForm;

--- a/src/components/thirdparty/mailchimp/PartnershipSignupForm.tsx
+++ b/src/components/thirdparty/mailchimp/PartnershipSignupForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import BaseForm from "./BaseForm";
 
@@ -11,9 +11,9 @@ const rawFormHTML = `
 	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
 </style>
 <div id="mc_embed_signup">
-<form action="https://sheltertech.us19.list-manage.com/subscribe/post?u=c47829732a0bea5c8e8a94604&amp;id=08f60e42ef" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+<form action="https://sheltertech.us19.list-manage.com/subscribe/post?u=c47829732a0bea5c8e8a94604&amp;id=b8938cc5c0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
     <div id="mc_embed_signup_scroll">
-
+	
 <div class="mc-field-group">
 	<label for="mce-EMAIL">Email Address </label>
 	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
@@ -27,27 +27,31 @@ const rawFormHTML = `
 	<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
 </div>
 <div class="mc-field-group">
-	<label for="mce-MMERGE12">Volunteer Interests </label>
-	<input type="text" value="" name="MMERGE12" class="" id="mce-MMERGE12">
+	<label for="mce-ORG">Organization Name </label>
+	<input type="text" value="" name="ORG" class="" id="mce-ORG">
+</div>
+<div class="mc-field-group">
+	<label for="mce-MSG">Message </label>
+	<input type="text" value="" name="MSG" class="" id="mce-MSG">
 </div>
 	<div id="mce-responses" class="clear">
 		<div class="response" id="mce-error-response" style="display:none"></div>
 		<div class="response" id="mce-success-response" style="display:none"></div>
 	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_c47829732a0bea5c8e8a94604_08f60e42ef" tabindex="-1" value=""></div>
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_c47829732a0bea5c8e8a94604_b8938cc5c0" tabindex="-1" value=""></div>
     <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
     </div>
 </form>
 </div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';fnames[6]='MMERGE6';ftypes[6]='text';fnames[7]='MMERGE7';ftypes[7]='number';fnames[8]='MMERGE8';ftypes[8]='date';fnames[9]='MMERGE9';ftypes[9]='text';fnames[10]='LGL_SAL';ftypes[10]='text';fnames[11]='LGL_ID';ftypes[11]='text';fnames[12]='MMERGE12';ftypes[12]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='ORG';ftypes[5]='text';fnames[6]='MSG';ftypes[6]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
 <!--End mc_embed_signup-->
 `;
 
-const VolunteerSignupForm = () => (
+const PartnershipSignupForm = () => (
   <BaseForm
     title="Work With Us"
     description="Thank you for your interest in partnering with ShelterTech! Enter your contact information below and we'll get back to you shortly."
     rawFormHTML={rawFormHTML}
   />
 );
-export default VolunteerSignupForm;
+export default PartnershipSignupForm;

--- a/src/components/thirdparty/mailchimp/VolunteerSignupForm.tsx
+++ b/src/components/thirdparty/mailchimp/VolunteerSignupForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 import BaseForm from "./BaseForm";
 
@@ -11,9 +11,9 @@ const rawFormHTML = `
 	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
 </style>
 <div id="mc_embed_signup">
-<form action="https://sheltertech.us19.list-manage.com/subscribe/post?u=c47829732a0bea5c8e8a94604&amp;id=b8938cc5c0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+<form action="https://sheltertech.us19.list-manage.com/subscribe/post?u=c47829732a0bea5c8e8a94604&amp;id=08f60e42ef" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
     <div id="mc_embed_signup_scroll">
-	
+
 <div class="mc-field-group">
 	<label for="mce-EMAIL">Email Address </label>
 	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
@@ -27,31 +27,27 @@ const rawFormHTML = `
 	<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
 </div>
 <div class="mc-field-group">
-	<label for="mce-ORG">Organization Name </label>
-	<input type="text" value="" name="ORG" class="" id="mce-ORG">
-</div>
-<div class="mc-field-group">
-	<label for="mce-MSG">Message </label>
-	<input type="text" value="" name="MSG" class="" id="mce-MSG">
+	<label for="mce-MMERGE12">Volunteer Interests </label>
+	<input type="text" value="" name="MMERGE12" class="" id="mce-MMERGE12">
 </div>
 	<div id="mce-responses" class="clear">
 		<div class="response" id="mce-error-response" style="display:none"></div>
 		<div class="response" id="mce-success-response" style="display:none"></div>
 	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_c47829732a0bea5c8e8a94604_b8938cc5c0" tabindex="-1" value=""></div>
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_c47829732a0bea5c8e8a94604_08f60e42ef" tabindex="-1" value=""></div>
     <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
     </div>
 </form>
 </div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='ORG';ftypes[5]='text';fnames[6]='MSG';ftypes[6]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';fnames[6]='MMERGE6';ftypes[6]='text';fnames[7]='MMERGE7';ftypes[7]='number';fnames[8]='MMERGE8';ftypes[8]='date';fnames[9]='MMERGE9';ftypes[9]='text';fnames[10]='LGL_SAL';ftypes[10]='text';fnames[11]='LGL_ID';ftypes[11]='text';fnames[12]='MMERGE12';ftypes[12]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
 <!--End mc_embed_signup-->
 `;
 
-const PartnershipSignupForm = () => (
+const VolunteerSignupForm = () => (
   <BaseForm
     title="Work With Us"
     description="Thank you for your interest in partnering with ShelterTech! Enter your contact information below and we'll get back to you shortly."
     rawFormHTML={rawFormHTML}
   />
 );
-export default PartnershipSignupForm;
+export default VolunteerSignupForm;


### PR DESCRIPTION
Closes #188.

This is a relatively straightforward conversion from JavaScript to TypeScript. I tested this by viewing the Volunteer Signup Form in Storybook, where it seems to look correct to me, but I was unable to test this on the Gatsby development server due to https://github.com/ShelterTechSF/sheltertech.org/issues/197.