### PR TITLE
Convert ThreeParagraphBlock to TypeScript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,8 @@ module.exports = {
       "error",
       { extensions: [".js", ".jsx", ".tsx"] },
     ],
+    // Disable prop-types check because they're redundant with TypeScript.
+    "react/prop-types": ["off"],
   },
   overrides: [
     {

--- a/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.tsx
+++ b/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.tsx
@@ -1,39 +1,22 @@
-import PropTypes from "prop-types";
-import React from "react";
+import * as React from "react";
 
-import Button from "../../inline/Button";
+import Button, { ButtonProps } from "../../inline/Button";
 
 import s from "./ThreeParagraphBlock.module.css";
 
-/* PropType shapes */
-
-const ParagraphPropType = PropTypes.shape({
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
-  button: PropTypes.oneOfType([
-    PropTypes.exact({
-      text: PropTypes.string,
-      externalLink: PropTypes.string,
-    }),
-    PropTypes.exact({
-      text: PropTypes.string,
-      internalLink: PropTypes.string,
-    }),
-    PropTypes.exact({
-      text: PropTypes.string,
-      onClick: PropTypes.func,
-    }),
-  ]),
-});
-
-const ImagePropType = PropTypes.shape({
-  url: PropTypes.string.isRequired,
-  alt: PropTypes.string.isRequired,
-});
-
 /* Subcomponents */
 
-const ParagraphBlock = ({ title, description, button }) => {
+type ParagraphBlockProps = {
+  title: string;
+  description: string;
+  button?: ButtonProps;
+};
+
+const ParagraphBlock = ({
+  title,
+  description,
+  button,
+}: ParagraphBlockProps) => {
   let buttonWrapper;
 
   if (button) {
@@ -58,30 +41,12 @@ const ParagraphBlock = ({ title, description, button }) => {
   );
 };
 
-ParagraphBlock.propTypes = {
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
-  button: PropTypes.oneOfType([
-    PropTypes.exact({
-      text: PropTypes.string,
-      externalLink: PropTypes.string,
-    }),
-    PropTypes.exact({
-      text: PropTypes.string,
-      internalLink: PropTypes.string,
-    }),
-    PropTypes.exact({
-      text: PropTypes.string,
-      onClick: PropTypes.func,
-    }),
-  ]),
+type CTABlockProps = {
+  title: string;
+  buttons: ButtonProps[];
 };
 
-ParagraphBlock.defaultProps = {
-  button: null,
-};
-
-const CTABlock = ({ title, buttons }) => (
+const CTABlock = ({ title, buttons }: CTABlockProps) => (
   <div>
     <div className={s.ctaTitleBlock}>
       <div className={s.ctaTitle}>{title}</div>
@@ -96,18 +61,24 @@ const CTABlock = ({ title, buttons }) => (
   </div>
 );
 
-CTABlock.propTypes = {
-  title: PropTypes.string.isRequired,
-  buttons: PropTypes.arrayOf({
-    text: PropTypes.string.isRequired,
-    noHover: PropTypes.bool,
-    externalLink: PropTypes.string.isRequired,
-    internalLink: PropTypes.string.isRequired,
-    onClick: PropTypes.func.isRequired,
-  }).isRequired,
+/* Main component */
+
+type ImageProps = {
+  url: string;
+  alt: string;
 };
 
-/* Main component */
+type ThreeParagraphBlockProps = {
+  title: string;
+  paragraph1: ParagraphBlockProps;
+  paragraph2: ParagraphBlockProps;
+  paragraph3: ParagraphBlockProps;
+  leftBottomImage: ImageProps;
+  rightImage: ImageProps;
+  leftTopImage?: ImageProps;
+  ctaTitle?: string;
+  ctaButtons?: ButtonProps[];
+};
 
 const ThreeParagraphBlock = ({
   title,
@@ -119,8 +90,8 @@ const ThreeParagraphBlock = ({
   rightImage,
   ctaTitle,
   ctaButtons,
-}) => {
-  let optionalLeftTopImage;
+}: ThreeParagraphBlockProps) => {
+  let optionalLeftTopImage: JSX.Element;
   let leftBottomImageWrapperClassName = s.leftBottomImageWrapper;
 
   if (leftTopImage) {
@@ -212,42 +183,6 @@ const ThreeParagraphBlock = ({
       </div>
     </div>
   );
-};
-
-ThreeParagraphBlock.propTypes = {
-  title: PropTypes.string.isRequired,
-  paragraph1: ParagraphPropType.isRequired,
-  paragraph2: ParagraphPropType.isRequired,
-  paragraph3: ParagraphPropType.isRequired,
-  leftBottomImage: ImagePropType.isRequired,
-  rightImage: ImagePropType.isRequired,
-  leftTopImage: PropTypes.shape({
-    url: PropTypes.string,
-    alt: PropTypes.string,
-  }),
-  ctaTitle: PropTypes.string,
-  ctaButtons: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.exact({
-        text: PropTypes.string,
-        externalLink: PropTypes.string,
-      }),
-      PropTypes.exact({
-        text: PropTypes.string,
-        internalLink: PropTypes.string,
-      }),
-      PropTypes.exact({
-        text: PropTypes.string,
-        onClick: PropTypes.func,
-      }),
-    ])
-  ),
-};
-
-ThreeParagraphBlock.defaultProps = {
-  leftTopImage: null,
-  ctaTitle: null,
-  ctaButtons: null,
 };
 
 export default ThreeParagraphBlock;

--- a/src/components/inline/Button/Button.tsx
+++ b/src/components/inline/Button/Button.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import s from "./Button.module.css";
 
-type ButtonProps = {
+export type ButtonProps = {
   text: string;
   noHover?: boolean;
   externalLink?: string;

--- a/src/components/inline/Button/index.js
+++ b/src/components/inline/Button/index.js
@@ -1,1 +1,0 @@
-export { default, SubmitButton } from "./Button";

--- a/src/components/inline/Button/index.ts
+++ b/src/components/inline/Button/index.ts
@@ -1,0 +1,1 @@
+export { default, ButtonProps, SubmitButton } from "./Button";


### PR DESCRIPTION
Closes #182.

This ports the ThreeParagraphBlock component to TypeScript. Aside from the usual conversion of PropTypes definitions to TypeScript, there are two other things that I did here that I'd like feedback on:

- I exported the `ButtonProps` type definition from the Button component, since it's something I think we'll want to import and use across many of our components. I was debating between creating a separate file for common, shared types vs. just exporting the type from the `Button.tsx` module like I did, and I went with the latter, since I wanted to keep things simple. However, I'm open to moving it somewhere else, especially if in the future we have more common types like this.
- I disabled the `react/prop-types` ESLint rule. For some reason, after I made my changes here, I started getting the following errors:

    ```sh
    /Users/rxia/sheltertech/sheltertech.org/src/components/grid-aware/ThreeParagraphBlock/ThreeParagraphBlock.tsx
      120:32  error  'leftBottomImage.url' is missing in props validation     react/prop-types
      121:32  error  'leftBottomImage.alt' is missing in props validation     react/prop-types
      131:29  error  'paragraph1.title' is missing in props validation        react/prop-types
      132:35  error  'paragraph1.description' is missing in props validation  react/prop-types
      133:30  error  'paragraph1.button' is missing in props validation       react/prop-types
      138:29  error  'paragraph2.title' is missing in props validation        react/prop-types
      139:35  error  'paragraph2.description' is missing in props validation  react/prop-types
      140:30  error  'paragraph2.button' is missing in props validation       react/prop-types
      150:29  error  'paragraph3.title' is missing in props validation        react/prop-types
      151:35  error  'paragraph3.description' is missing in props validation  react/prop-types
      152:30  error  'paragraph3.button' is missing in props validation       react/prop-types
      156:50  error  'rightImage.url' is missing in props validation          react/prop-types
      156:71  error  'rightImage.alt' is missing in props validation          react/prop-types
    ```

    It seems that the `react/prop-types` rule has issues with nested types. Although the [rule indeed supports TypeScript type definitions](https://github.com/yannickcr/eslint-plugin-react/blob/v7.23.1/docs/rules/prop-types.md), I couldn't get it to work with the nested properties here. Since we're making good progress converting all the components to TypeScript, I don't think we need this ESLint rule enabled anymore, so I disabled it.