### PR TITLE
176 convert modal to typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8995,6 +8995,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-modal": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.12.0.tgz",
+      "integrity": "sha512-UnHu/YO73NZLwqFpju/c0tqiswR0UHIfeO16rkfLVJUIMfQsl7X0CBm99H5XXgBMe/PgtQ/Rkud72iuRBr1TeA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-syntax-highlighter": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/react": "^17.0.0",
     "@types/react-burger-menu": "^2.8.0",
     "@types/react-dom": "^17.0.0",
+    "@types/react-modal": "^3.12.0",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
     "babel-jest": "^26.6.0",

--- a/src/components/grid-aware/Modal/Modal.tsx
+++ b/src/components/grid-aware/Modal/Modal.tsx
@@ -7,7 +7,7 @@ import closeIcon from "./close-icon.svg";
 type ModalProps = {
   children: React.ReactNode;
   isOpen: boolean;
-  setIsOpen: (x: boolean) => null;
+  setIsOpen: (x: boolean) => void;
   ariaHideApp?: boolean; // we only ever set this to false for storybook
   contentLabel: string;
   noBezel?: boolean; // If true, then eliminate the padding and close button

--- a/src/components/grid-aware/Modal/Modal.tsx
+++ b/src/components/grid-aware/Modal/Modal.tsx
@@ -1,9 +1,17 @@
-import PropTypes from "prop-types";
-import React from "react";
+import * as React from "react";
 import ReactModal from "react-modal";
 
 import s from "./Modal.module.css";
 import closeIcon from "./close-icon.svg";
+
+type ModalProps = {
+  children: React.ReactNode;
+  isOpen: boolean;
+  setIsOpen: (x: boolean) => null;
+  ariaHideApp?: boolean; // we only ever set this to false for storybook
+  contentLabel: string;
+  noBezel?: boolean; // If true, then eliminate the padding and close button
+};
 
 const Modal = ({
   children,
@@ -12,18 +20,19 @@ const Modal = ({
   ariaHideApp,
   contentLabel,
   noBezel,
-}) => {
+}: ModalProps) => {
   const modalClassName = `${s.content} ${noBezel ? s.noBezel : s.withBezel}`;
   const buttonClassName = `${s.closeButton} ${
     noBezel ? s.noBezel : s.withBezel
   }`;
+  const ariaHide = ariaHideApp === undefined ? true : ariaHideApp;
   return (
     <ReactModal
       className={modalClassName}
       overlayClassName={s.overlay}
       isOpen={isOpen}
       onRequestClose={() => setIsOpen(false)}
-      ariaHideApp={ariaHideApp}
+      ariaHideApp={ariaHide}
       contentLabel={contentLabel}
     >
       <button
@@ -36,20 +45,6 @@ const Modal = ({
       {children}
     </ReactModal>
   );
-};
-
-Modal.propTypes = {
-  children: PropTypes.node.isRequired,
-  isOpen: PropTypes.bool.isRequired,
-  setIsOpen: PropTypes.func.isRequired,
-  ariaHideApp: PropTypes.bool,
-  contentLabel: PropTypes.string.isRequired,
-  noBezel: PropTypes.bool, // If true, then eliminate the padding and close button
-};
-
-Modal.defaultProps = {
-  ariaHideApp: true,
-  noBezel: false,
 };
 
 export default Modal;

--- a/src/components/grid-aware/Modal/Modal.tsx
+++ b/src/components/grid-aware/Modal/Modal.tsx
@@ -17,7 +17,7 @@ const Modal = ({
   children,
   isOpen,
   setIsOpen,
-  ariaHideApp,
+  ariaHideApp = true,
   contentLabel,
   noBezel,
 }: ModalProps) => {
@@ -25,14 +25,13 @@ const Modal = ({
   const buttonClassName = `${s.closeButton} ${
     noBezel ? s.noBezel : s.withBezel
   }`;
-  const ariaHide = ariaHideApp === undefined ? true : ariaHideApp;
   return (
     <ReactModal
       className={modalClassName}
       overlayClassName={s.overlay}
       isOpen={isOpen}
       onRequestClose={() => setIsOpen(false)}
-      ariaHideApp={ariaHide}
+      ariaHideApp={ariaHideApp}
       contentLabel={contentLabel}
     >
       <button

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
     // Strict Checks
     "strict": true,
 
+    // Module Resolution
+    "esModuleInterop": true, // Allows us to use default imports with CommonJS modules (which some third-party packages use)
+
     // Advanced
     "skipLibCheck": true // Don't type check .d.ts files, which mostly come from third party libraries.
   },


### PR DESCRIPTION
Closes #176 

Converts the `<Modal>` component to typescript. Only three comments about this:

1. `ariaHideApp` is an optional prop with a default of `true`, but TypeScript doesn't directly have a way of handling optional props. I investigated making it required, but we only ever need to set this to `false` for Storybook. It should generally always be `true` for accessibility reasons, so manually passing it around everywhere would feel a bit tedious. 
So I instead slapped together this "default" logic: `const ariaHide = ariaHideApp === undefined ? true : ariaHideApp;`, but if someone has oppositions to this kind of ternary operator, I'm open to alternatives.

2. TypeScript didn't want me to do a default import of react-modal, so I tried importing it like so: `import * as ReactModal from "react-modal";`. But our storybook/jest configuration absolutely hated this and kept failing tests for no good reason. I could not figure out how to placate it, so I reconfigured TypeScript instead -- to get TypeScript to agree with the default import, I had to set `esModuleInterop` to `true` in our `tsconfig.json`.

3. Discovered a weird bug 🐛 I tested the modals in storybook and locally to ensure the behavior didn't change. We have 4 modals in total, and 3 of them worked as expected. But the modal toggled in `<VideoSpotlightBlock>` doesn't open in Firefox (my default browser). It does, however, open in Chrome! I checked the live site and, surprisingly, it's the same situation there. Anyway, because it's in production, it should be unrelated to this PR. I can open a separate issue for investigating that.

