### PR TITLE
Initial Prismic integration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,8 @@ module.exports = {
       // Gatsby configuration files
       files: ["gatsby-config.js"],
       rules: {
+        // global-require is fine because this is a Node.js script.
+        "global-require": "off",
         "import/no-extraneous-dependencies": [
           "error",
           { devDependencies: true },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,8 +27,35 @@ module.exports = {
         postCssPlugins: [postcssCustomMedia],
       },
     },
-    // this (optional) plugin enables Progressive Web App + Offline functionality
-    // To learn more, visit: https://gatsby.dev/offline
-    // 'gatsby-plugin-offline',
+    {
+      // See https://github.com/angeloashmore/gatsby-source-prismic for the full
+      // list of options.
+      resolve: "gatsby-source-prismic",
+      options: {
+        // The name of your prismic.io repository. This is required.
+        // Example: 'gatsby-source-prismic-test-site' if your prismic.io address
+        // is 'gatsby-source-prismic-test-site.prismic.io'.
+        repositoryName: "sheltertech",
+
+        // Set a list of links to fetch and be made available in your link
+        // resolver function.
+        // See: https://prismic.io/docs/javascript/query-the-api/fetch-linked-document-fields
+        fetchLinks: [
+          // Your list of links
+        ],
+
+        // Provide an object of Prismic custom type JSON schemas to load into
+        // Gatsby. This is required.
+        schemas: {
+          // Your custom types mapped to schemas
+          footer: require("./src/schemas/footer.json"),
+        },
+
+        // Add the Prismic Toolbar script to the site. Defaults to false.
+        // Set to "legacy" if your repository requires the older toolbar script.
+        // See: https://prismic.io/docs/rest-api/beyond-the-api/the-preview-feature
+        prismicToolbar: true,
+      },
+    },
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4139,6 +4139,16 @@
         "schema-utils": "^2.6.5"
       }
     },
+    "@prismicio/helpers": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-1.0.5.tgz",
+      "integrity": "sha512-TPpuAFHNxlCTrEihHnRKcq6zc0oZV0sfz5/iHoSpl5vorwPbwZWiF88JGeflNdefW4A69b5A3x3mfptKPdpoxg=="
+    },
+    "@prismicio/richtext": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-1.1.0.tgz",
+      "integrity": "sha512-925JuFiZiIkwu9jmlR9O/U8xCSZk/Y6BQDXKpavoVsKo+n90ml1hGdtWkglIupX+ITQO1ZINyDgUgiY1oG9dsA=="
+    },
     "@reach/alert": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@reach/alert/-/alert-0.10.3.tgz",
@@ -13003,6 +13013,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "chokidar": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
@@ -14016,6 +14031,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -15178,7 +15198,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
       "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
-      "dev": true,
       "requires": {
         "no-case": "^3.0.3",
         "tslib": "^1.10.0"
@@ -15634,6 +15653,11 @@
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
       "dev": true
+    },
+    "es-cookie": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
+      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q=="
     },
     "es-get-iterator": {
       "version": "1.1.0",
@@ -17730,6 +17754,11 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
+    "fp-ts": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.9.5.tgz",
+      "integrity": "sha512-MiHrA5teO6t8zKArE3DdMPT/Db6v2GUt5yfWnhBTrrsVfeCJUUnV6sgFvjGNBKDmEMqVwRFkEePL7wPwqrLKKA=="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -18501,6 +18530,26 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        }
+      }
+    },
+    "gatsby-plugin-imgix": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-imgix/-/gatsby-plugin-imgix-0.8.2.tgz",
+      "integrity": "sha512-1ujoVMhZxLnOhaClboLkjE42y1btIWnveDVXT/Qpyogr5OsziaGiJnZP/dMg9pWTk6/O3Xu5MCqJal1fzzdQ2w==",
+      "requires": {
+        "camel-case": "^4.1.1",
+        "fp-ts": "^2.6.2",
+        "imgix-url-params": "^11.4.3",
+        "md5": "^2.2.1",
+        "node-fetch": "^2.6.0",
+        "param-case": "^3.0.3"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -19283,7 +19332,6 @@
       "version": "2.3.24",
       "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.3.24.tgz",
       "integrity": "sha512-TiuuV7sczagVOKW94dfx1AkW/wfe678UOdBAJrMxA2wZvuTe/gXz4Vg4F+EJIoZ8pyy8BjQbclmqXEnGX4eYKw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.3",
         "better-queue": "^3.8.10",
@@ -19306,7 +19354,6 @@
           "version": "7.11.2",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
           "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -19314,14 +19361,12 @@
         "file-type": {
           "version": "12.4.2",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
-          "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==",
-          "dev": true
+          "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
         },
         "got": {
           "version": "9.6.0",
           "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
           "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-          "dev": true,
           "requires": {
             "@sindresorhus/is": "^0.14.0",
             "@szmarczak/http-timer": "^1.1.2",
@@ -19339,14 +19384,39 @@
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "xstate": {
           "version": "4.11.0",
           "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.11.0.tgz",
-          "integrity": "sha512-v+S3jF2YrM2tFOit8o7+4N3FuFd9IIGcIKHyfHeeNjMlmNmwuiv/IbY9uw7ECifx7H/A9aGLcxPSr0jdjTGDww==",
-          "dev": true
+          "integrity": "sha512-v+S3jF2YrM2tFOit8o7+4N3FuFd9IIGcIKHyfHeeNjMlmNmwuiv/IbY9uw7ECifx7H/A9aGLcxPSr0jdjTGDww=="
+        }
+      }
+    },
+    "gatsby-source-prismic": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/gatsby-source-prismic/-/gatsby-source-prismic-3.3.4.tgz",
+      "integrity": "sha512-xb/FO51Vxa1LNk5Zsv//JEHThHbJXnCLS431Qd3b6x6R3nMH08w2RpPKYBtvfEF3gBLY51sZjKlhnYobZE+H2A==",
+      "requires": {
+        "camel-case": "^4.1.1",
+        "es-cookie": "^1.3.2",
+        "gatsby-plugin-imgix": "^0.8.1",
+        "gatsby-source-filesystem": "^2.3.23",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "md5": "^2.2.1",
+        "pascal-case": "^3.1.1",
+        "prismic-dom": "^2.2.3",
+        "prismic-javascript": "^2.7.1",
+        "superstruct": "^0.10.12",
+        "uuid": "^8.2.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -20718,6 +20788,11 @@
           "dev": true
         }
       }
+    },
+    "imgix-url-params": {
+      "version": "11.11.2",
+      "resolved": "https://registry.npmjs.org/imgix-url-params/-/imgix-url-params-11.11.2.tgz",
+      "integrity": "sha512-T0XU7g1CyNLwcuKWPpuhItFs7XhzMLKVkH9udmRGxaGXycjL2l93rvXhAEz/Ur5X8Z5Nyzet+FszrXo98xEzhw=="
     },
     "immer": {
       "version": "1.10.0",
@@ -26055,6 +26130,11 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -26069,6 +26149,16 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.sample": {
       "version": "4.2.1",
@@ -26452,6 +26542,16 @@
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "dev": true
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
     },
     "md5-file": {
       "version": "3.2.3",
@@ -28127,7 +28227,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
       "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
-      "dev": true,
       "requires": {
         "dot-case": "^3.0.3",
         "tslib": "^1.10.0"
@@ -29345,8 +29444,7 @@
     "pretty-bytes": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
-      "dev": true
+      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -29403,6 +29501,36 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
+    "prismic-dom": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/prismic-dom/-/prismic-dom-2.2.5.tgz",
+      "integrity": "sha512-GafsY6sGet5EAWNG2w/qXaxgitU74yhEu/0vZEnwOt6PJgCClLmMkDzJHBpdl+wuEWqUhvkFMDUFPHSPwSVmKQ==",
+      "requires": {
+        "@prismicio/helpers": "^1.0.4",
+        "@prismicio/richtext": "^1.1.0",
+        "escape-html": "1.0.3"
+      }
+    },
+    "prismic-javascript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prismic-javascript/-/prismic-javascript-2.7.1.tgz",
+      "integrity": "sha512-4Mm2jBtQzjwN57est94wKFR6twvs3AhKx0BOR2IztUFyUEJhIp6iFHXNMQqTMP/q4cZ56hL0BtK5ecBkylNcyA==",
+      "requires": {
+        "cross-fetch": "^2.2.3",
+        "promise-polyfill": "8.0.0"
+      },
+      "dependencies": {
+        "cross-fetch": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+          "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+          "requires": {
+            "node-fetch": "2.1.2",
+            "whatwg-fetch": "2.0.4"
+          }
+        }
+      }
+    },
     "prismjs": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
@@ -29451,6 +29579,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "promise-polyfill": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.0.0.tgz",
+      "integrity": "sha512-QGmPnw2hDEaRS6freHynJ7nfS1nDg0/P0c/CGglA43utoJjYQMiY9ojEpK0HaJ4wbUztdmwqQRlEfGWdsEQ5uQ=="
     },
     "promise.allsettled": {
       "version": "1.0.2",
@@ -30533,7 +30666,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
       "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
-      "dev": true,
       "requires": {
         "pify": "^4.0.1",
         "with-open-file": "^0.1.6"
@@ -30542,8 +30674,7 @@
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
     },
@@ -33788,6 +33919,11 @@
         "postcss": "^7.0.2"
       }
     },
+    "superstruct": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.10.13.tgz",
+      "integrity": "sha512-W4SitSZ9MOyMPbHreoZVEneSZyPEeNGbdfJo/7FkJyRs/M3wQRFzq+t3S/NBwlrFSWdx1ONLjLb9pB+UKe4IqQ=="
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -35100,8 +35236,7 @@
     "valid-url": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
-      "dev": true
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -35899,7 +36034,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.7.tgz",
       "integrity": "sha512-ecJS2/oHtESJ1t3ZfMI3B7KIDKyfN0O16miWxdn30zdh66Yd3LsRFebXZXq6GU4xfxLf6nVxp9kIqElb5fqczA==",
-      "dev": true,
       "requires": {
         "p-finally": "^1.0.0",
         "p-try": "^2.1.0",
@@ -35909,8 +36043,7 @@
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/ShelterTechSF/sheltertech.org#readme",
   "dependencies": {
     "gatsby": "^2.24.47",
+    "gatsby-source-prismic": "^3.3.4",
     "normalize.css": "^8.0.1",
     "prop-types": "^15.7.2",
     "pure-react-carousel": "^1.27.6",

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -26,10 +26,11 @@ const navigationItems: NavItem[] = [
 ];
 
 type LayoutProps = {
+  footerAddress: string;
   children: React.ReactNode;
 };
 
-const Layout = ({ children }: LayoutProps) => {
+const Layout = ({ footerAddress, children }: LayoutProps) => {
   const pageWrapperID = "page-wrapper";
   const outerContainerID = "outer-container";
   const [burgerMenuIsOpen, setBurgerMenuIsOpen] = useState(false);
@@ -122,7 +123,7 @@ const Layout = ({ children }: LayoutProps) => {
               alt: "GitHub Logo",
             },
           ]}
-          address="268 Bush Street #4302, San Francisco CA, 94104 USA"
+          address={footerAddress}
           employerIdentificationNumber="EIN: 38-3984099"
         />
       </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,8 @@
+// TODO: Figure out how to get stricter types out of Gatsby GraphQL queries.
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { graphql } from "gatsby";
 import * as React from "react";
 import { useState } from "react";
 
@@ -26,15 +31,28 @@ import partnersAndSponsorsLogos from "../data/partnersAndSponsorsLogos";
 import annualReportPDF from "./ShelterTech-Annual-Report-2019-Q1.pdf";
 import articleSpotlightImage from "./mission-hotel.jpeg";
 
-export default () => {
+export const query = graphql`
+  query MyQuery {
+    prismicFooter {
+      data {
+        address {
+          text
+        }
+      }
+    }
+  }
+`;
+
+export default ({ data }: any) => {
   const [partnershipFormIsOpen, setPartnershipFormIsOpen] = useState(false);
   const [videoHeaderModalIsOpen, setVideoHeaderModalIsOpen] = useState(false);
   const [
     videoSpotlightBlockModalIsOpen,
     setVideoSpotlightBlockModalIsOpen,
   ] = useState(false);
+  const footerAddress = data.prismicFooter.data.address.text;
   return (
-    <Layout>
+    <Layout footerAddress={footerAddress}>
       <Modal
         isOpen={partnershipFormIsOpen}
         setIsOpen={setPartnershipFormIsOpen}

--- a/src/schemas/footer.json
+++ b/src/schemas/footer.json
@@ -1,0 +1,12 @@
+{
+  "Main": {
+    "address": {
+      "type": "StructuredText",
+      "config": {
+        "single": "paragraph",
+        "label": "Address",
+        "placeholder": "123 Fake St, San Francisco, California 94110"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves #225. Note that this PR targets a new branch named `prismic`, not `main`. More on that later in the PR description.

This PR includes some small changes to have this Gatsby application talk to [Prismic](https://prismic.io/), the content management system (CMS) we're planning to integrate with. I've installed [gatsby-source-prismic](https://github.com/angeloashmore/gatsby-source-prismic), which is the Gatsby plugin that [is officially supported by Prismic](https://prismic.io/docs/technologies/plugin-configuration-gatsby), and connected it to our Prismic account.

As the most basic demonstration of an integration with Prismic, we're now fetching the `address` field from the `Footer` object from Prismic, using that data to populate the address at the very bottom right of the footer. In even doing this, we've already encountered several issues that we've broken up into GitHub tickets to tackle separately.

@jessica-px and I pair programmed on most of this, and although it's far from complete, we think it's a useful, PR-able first step. We're planning to use a new branch named `prismic` as a longer-running integration branch so that we keep the production site isolated from these changes. This will allow us to explore and experiment more without impacting the production site and give us the freedom to change our minds any part of the setup. This also gives us the freedom to completely wipe the data and data schemas defined in Prismic, which is not something we'd be able to easily do after launching this in production.

Anyone should be able to check out this branch, `npm install` the new dependencies, and run the Gatsby development server to see data being fetched from Prismic. You don't even need the Prismic account credentials because the API endpoint is public. You can tell if it's working if you see "268 Bush Street2" as the address in the footer, since I had intentionally altered the address to test the integration.