### PR TITLE
Add support for Prismic link resolving

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,7 @@
 const postcssCustomMedia = require("postcss-custom-media");
 
+const linkResolver = require("./src/utils/linkResolver");
+
 module.exports = {
   siteMetadata: {
     title: "ShelterTech - Technology for the underserved",
@@ -37,6 +39,8 @@ module.exports = {
         // Example: 'gatsby-source-prismic-test-site' if your prismic.io address
         // is 'gatsby-source-prismic-test-site.prismic.io'.
         repositoryName: "sheltertech",
+
+        linkResolver,
 
         // Provide an object of Prismic custom type JSON schemas to load into
         // Gatsby. This is required.

--- a/src/components/grid-aware/Footer/NavigationBlock/NavigationBlock.tsx
+++ b/src/components/grid-aware/Footer/NavigationBlock/NavigationBlock.tsx
@@ -1,5 +1,8 @@
 import { Link } from "gatsby";
 import * as React from "react";
+
+import PrismicLink from "../../../inline/PrimsicLink";
+import type { MinimalPrismicLinkType } from "../../../inline/PrimsicLink";
 import * as s from "./NavigationBlock.module.css";
 
 /* PropType shapes */
@@ -19,6 +22,7 @@ export type SealProps = {
 export type ShelterTechLogoProps = {
   url: string;
   alt: string;
+  link?: MinimalPrismicLinkType;
 };
 
 export type SocialMediaLinkProps = {
@@ -37,7 +41,9 @@ const NavigationLeftArea = ({
   socialMediaLinks,
 }: NavigationLeftAreaProps) => (
   <div>
-    <img src={shelterTechLogo.url} alt={shelterTechLogo.alt} />
+    <PrismicLink linkData={shelterTechLogo.link}>
+      <img src={shelterTechLogo.url} alt={shelterTechLogo.alt} />
+    </PrismicLink>
     <div className={s.socialMediaLinks}>
       {socialMediaLinks.map((socialMediaLink) => (
         <a

--- a/src/components/inline/PrimsicLink.tsx
+++ b/src/components/inline/PrimsicLink.tsx
@@ -1,0 +1,49 @@
+import { Link as GatsbyLink } from "gatsby";
+import React from "react";
+
+import linkResolver from "../../utils/linkResolver";
+
+/** A Prismic Link with only the minimal set of properties for link resolving.
+ *
+ * Most of these fields come from
+ * https://prismic.io/docs/technologies/link-resolver-javascript#accessible-attributes,
+ * with the exception of link_type, which is one of "Document", "Web", and
+ * "Media".
+ */
+export type MinimalPrismicLinkType = Pick<
+  GatsbyTypes.PrismicLinkType,
+  "isBroken" | "link_type" | "target" | "type" | "uid"
+>;
+
+type PrismicLinkProps = {
+  linkData?: MinimalPrismicLinkType;
+  children: React.ReactNode;
+};
+
+/** Link with properties that come from Prismic.
+ *
+ * `linkData` should be an object that comes directly from a Prismic Link field.
+ *
+ * Loosely based on the official example in
+ * https://prismic.io/docs/technologies/link-resolver-gatsby
+ */
+const PrismicLink = ({ linkData, children }: PrismicLinkProps): JSX.Element => {
+  if (linkData === undefined) return <>{children}</>;
+  switch (linkData.link_type) {
+    case "Document":
+      return <GatsbyLink to={linkResolver(linkData)}>{children}</GatsbyLink>;
+    case "Web":
+    case "Media":
+      return (
+        <a href={linkResolver(linkData)} target={linkData.target}>
+          {children}
+        </a>
+      );
+    default:
+      throw new Error(
+        `Unhandled link type: ${linkData.link_type ?? "undefined"}`
+      );
+  }
+};
+
+export default PrismicLink;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -45,6 +45,13 @@ const Layout = ({ children }: LayoutProps) => {
           address {
             text
           }
+          sheltertech_logo_link {
+            isBroken
+            link_type
+            target
+            type
+            uid
+          }
         }
       }
     }
@@ -112,6 +119,7 @@ const Layout = ({ children }: LayoutProps) => {
           shelterTechLogo={{
             url: shelterTechLogoWhite,
             alt: "ShelterTech Logo",
+            link: data.prismicFooter?.data?.sheltertech_logo_link,
           }}
           socialMediaLinks={[
             {

--- a/src/schemas/footer.json
+++ b/src/schemas/footer.json
@@ -1,11 +1,17 @@
 {
-  "Main": {
-    "address": {
-      "type": "StructuredText",
-      "config": {
-        "single": "paragraph",
-        "label": "Address",
-        "placeholder": "123 Fake St, San Francisco, California 94110"
+  "Main" : {
+    "address" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "paragraph",
+        "label" : "Address",
+        "placeholder" : "123 Fake St, San Francisco, California 94110"
+      }
+    },
+    "sheltertech_logo_link" : {
+      "type" : "Link",
+      "config" : {
+        "label" : "ShelterTech Logo Link"
       }
     }
   }

--- a/src/utils/linkResolver.js
+++ b/src/utils/linkResolver.js
@@ -1,0 +1,27 @@
+// Note: This file cannot be written in TypeScript because it is imported by
+// gatsby-config.js.
+
+/** A link resolver function for Prismic.
+ *
+ * Accepts a description of an arbitrary Prismic document of any type and
+ * returns a string URL to the document.
+ *
+ * See https://prismic.io/docs/technologies/link-resolver-javascript for the
+ * available properties on the `doc` argument.
+ */
+const linkResolver = (doc) => {
+  switch (doc.type) {
+    case "home_page":
+      return "/";
+    default:
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Could not resolve the following document to a URL: ${JSON.stringify(
+          doc
+        )}`
+      );
+      return "/";
+  }
+};
+
+module.exports = linkResolver;


### PR DESCRIPTION
Resolves #235. This targets the `prismic` branch, not `main`.

## Overview

This adds some support for Prismic link resolving, which allows us to take Prismic's representation of a link and map it onto our internal page routes and React components. There are a few layers of preexisting things in Prismic and the associated Gatsby plugin, so let me first explain them before going into what I did in this PR.

## Background

Prismic has its own concept of a [Link](https://prismic.io/docs/core-concepts/link-content-relationship), which content creators can use create links to other internal pages, external sites, or file uploads. These can live either in Link fields or in Rich Text fields, the latter of which provides a very high amount of flexibility on the content creator's side, and therefore means our site would needs to support that flexibility. These two scenarios are handled separately in Gatsby, since the use cases are different enough.

The `gatsby-source-prismic` has direct support for link resolving, and the v4 version of the plugin aligns more closely with Prismic's representation. The [current docs on Prismic's](https://prismic.io/docs/technologies/link-resolver-gatsby) website still reference the v3 version of the `gatsby-source-prismic` plugin, but I actually found Prismic's non-Gatsby, pure JavaScript docs on [link resolving](https://prismic.io/docs/technologies/link-resolver-javascript) has better documentation on the properties you can expect to get from the Prismic API. Some of the more important fields are the `type`, which tells you which custom type on Prismic it corresponds to, the `uid` and the user-friendly ID for resource being linked to.

Finally, there's one last property that they return that I couldn't find much documentation for, but it's the `link_type`, which can be one of `Document` (internal Prismic document), `Web` (external link), or `Media` (file upload).

## Changes made in this PR

There were two utilities that I created: a `linkResolver()` function and a `<PrismicLink>` React component.

The `linkResolver()` just takes in a Prismic link object and returns a string URL, and it's used in the `gatsby-config.js` for configuring `gatsby-source-prismic` itself. It currently only returns the URL for the home page, but as we add new pages, we'll need to add them to the `linkResolver()` function so that they are routed properly.

The `<PrismicLink>` React component I created is meant to take any arbitrary Prismic link and return either a `<GatsbyLink>`, for internal pages, or a regular `<a>` tag, for external pages or media files. So far I've only used it manually in one of our components, but I think this is something we can also pass into the rendering of a Rich Text field, which the `gatsby-source-prismic` plugin can handle. I haven't tested the Rich Text field integration yet, but I think that can happen in a followup PR.

I made a minor change to the footer so that the ShelterTech logo is now a link to the Home Page, which is configured as a Prismic Link on our Footer type in Prismic.

I think the last thing to note is that you have to query quite a few fields within the Prismic field type to so that we have all the fields necessary for link resolver. As far as I can tell, we just have to explicitly write these fields down in the GraphQL query, but is there some way for us to specify the same set of fields for all link types?