### PR TITLE
Fix Gatsby warnings

### DIFF
--- a/src/components/grid-aware/Navigation/BurgerMenu.tsx
+++ b/src/components/grid-aware/Navigation/BurgerMenu.tsx
@@ -6,13 +6,7 @@ import * as s from "./BurgerMenu.module.css";
 import { NavigationItem } from "./types";
 
 /** An internal, external, or button link. */
-const NavLink = ({
-  text,
-  internalLink,
-  externalLink,
-  isButton = false,
-}: NavigationItem) => {
-  const className = `${s.navLink} ${isButton ? s.button : ""}`;
+const NavLink = ({ text, internalLink, externalLink }: NavigationItem) => {
   if (internalLink) {
     // Enable the "active" style for any nested pages, except for the home page,
     // which would be a parent page for any page. This is also used to get
@@ -23,7 +17,7 @@ const NavLink = ({
     const isPartiallyActive = internalLink.replace(/\/$/, "") !== "";
     return (
       <Link
-        className={className}
+        className={s.navLink}
         activeClassName={s.currentPage}
         to={internalLink}
         partiallyActive={isPartiallyActive}
@@ -35,7 +29,7 @@ const NavLink = ({
   if (externalLink) {
     return (
       <a
-        className={className}
+        className={s.navLink}
         href={externalLink}
         target="_blank"
         rel="noreferrer"

--- a/src/components/grid-aware/ProgramBlock/ProgramBlock.tsx
+++ b/src/components/grid-aware/ProgramBlock/ProgramBlock.tsx
@@ -29,14 +29,13 @@ const ProgramBlock = ({
       <div className={s.description}>{description}</div>
       <div className={s.ctaButtonRow}>
         {ctaButtons.map((button) => (
-          <div className={s.ctaButtonRowItem} key={button.text}>
-            <Button
-              text={button.text}
-              internalLink={button.internalLink}
-              externalLink={button.externalLink}
-              onClick={button.onClick}
-            />
-          </div>
+          <Button
+            key={button.text}
+            text={button.text}
+            internalLink={button.internalLink}
+            externalLink={button.externalLink}
+            onClick={button.onClick}
+          />
         ))}
       </div>
     </div>

--- a/src/components/inline/Button/index.ts
+++ b/src/components/inline/Button/index.ts
@@ -1,1 +1,2 @@
-export { default, ButtonProps, SubmitButton } from "./Button";
+export { default, SubmitButton } from "./Button";
+export type { ButtonProps } from "./Button";


### PR DESCRIPTION
This fixes the warnings that get printed out when running the Gatsby development server. Two of the warnings are caused by trying to use CSS classes that don't actually exist in a CSS module, which for some reason is only a warning, not an error. The remaining warning is due to attempting to re-export a TypeScript-only type from a module, which can be fixed by splitting up the exports into normal exports and type exports.

I'd ideally like the warnings to be flagged as errors, at least in CI, but I couldn't figure out a simple way of doing that.