### PR TITLE
Reduce boilerplate for Prismic link queries

### DIFF
--- a/src/components/inline/PrimsicLink.tsx
+++ b/src/components/inline/PrimsicLink.tsx
@@ -1,4 +1,4 @@
-import { Link as GatsbyLink } from "gatsby";
+import { Link as GatsbyLink, graphql } from "gatsby";
 import React from "react";
 
 import linkResolver from "../../utils/linkResolver";
@@ -45,5 +45,16 @@ const PrismicLink = ({ linkData, children }: PrismicLinkProps): JSX.Element => {
       );
   }
 };
+
+export const query = graphql`
+  # The minimum set of data required for the <PrismicLink> component.
+  fragment MinimalPrismicLinkData on PrismicLinkType {
+    isBroken
+    link_type
+    target
+    type
+    uid
+  }
+`;
 
 export default PrismicLink;

--- a/src/components/inline/PrimsicLink.tsx
+++ b/src/components/inline/PrimsicLink.tsx
@@ -1,18 +1,17 @@
 import { Link as GatsbyLink, graphql } from "gatsby";
 import React from "react";
 
-import linkResolver from "../../utils/linkResolver";
-
 /** A Prismic Link with only the minimal set of properties for link resolving.
  *
- * Most of these fields come from
+ * Most of the fields on PrismicLinkType come from
  * https://prismic.io/docs/technologies/link-resolver-javascript#accessible-attributes,
  * with the exception of link_type, which is one of "Document", "Web", and
- * "Media".
+ * "Media", and url, which is the result of applying our linkResolver function
+ * to a link.
  */
 export type MinimalPrismicLinkType = Pick<
   GatsbyTypes.PrismicLinkType,
-  "isBroken" | "link_type" | "target" | "type" | "uid"
+  "link_type" | "target" | "url"
 >;
 
 type PrismicLinkProps = {
@@ -28,14 +27,14 @@ type PrismicLinkProps = {
  * https://prismic.io/docs/technologies/link-resolver-gatsby
  */
 const PrismicLink = ({ linkData, children }: PrismicLinkProps): JSX.Element => {
-  if (linkData === undefined) return <>{children}</>;
+  if (linkData === undefined || !linkData.url) return <>{children}</>;
   switch (linkData.link_type) {
     case "Document":
-      return <GatsbyLink to={linkResolver(linkData)}>{children}</GatsbyLink>;
+      return <GatsbyLink to={linkData.url}>{children}</GatsbyLink>;
     case "Web":
     case "Media":
       return (
-        <a href={linkResolver(linkData)} target={linkData.target}>
+        <a href={linkData.url} target={linkData.target}>
           {children}
         </a>
       );
@@ -49,11 +48,9 @@ const PrismicLink = ({ linkData, children }: PrismicLinkProps): JSX.Element => {
 export const query = graphql`
   # The minimum set of data required for the <PrismicLink> component.
   fragment MinimalPrismicLinkData on PrismicLinkType {
-    isBroken
     link_type
     target
-    type
-    uid
+    url
   }
 `;
 

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -46,11 +46,7 @@ const Layout = ({ children }: LayoutProps) => {
             text
           }
           sheltertech_logo_link {
-            isBroken
-            link_type
-            target
-            type
-            uid
+            ...MinimalPrismicLinkData
           }
         }
       }


### PR DESCRIPTION
Fixes #275.

This is actually two completely separate changes, where the second change isn't really related to the associated issue, so you may find reviewing the individual commits easier.

The main changes are in https://github.com/ShelterTechSF/sheltertech.org/commit/e47ff466dee714329dbb7d39481cdaa1107b6187, where I created a GraphQL fragment named `MinimalPrismicLinkData` to hold the minimum set of fields needed needed for rendering the `<PrismicLink>` component I had created in an earlier PR. It's a bit of Gatsby magic, but simply exporting a variable named `query` in any component that is eventually imported by a page is enough for the fragment to be registered, which is why it is legal to reference `MinimalPrismicLinkData` from the query in `layout.tsx`. See https://prismic.io/docs/technologies/fragments-gatsby for some docs on how this works in the Gatsby Prismic plugin we use.

The second commit (https://github.com/ShelterTechSF/sheltertech.org/commit/f11fca34a91aa9291828a559b01dce7fd1c71e6a) is technically unrelated, and I can split it out into a separate PR if preferred. Here I significantly trimmed down on the number of fields being queried, since I discovered that the Gatsby Prismic plugin adds a special GraphQL field named `url` to PrismicLinkType objects. This actually holds the URL after being resolved by the `linkResolver()` function. This is once again a bit of magic, this time [by the Gatsby Prismic plugin](https://prismic.io/docs/technologies/link-resolver-gatsby#3.-usage), but I figured out that if we use this, we don't need the `<PrismicLink>` component to import and call the `linkResolver()` function on its own. When we remove the dependency on the `linkResolver()`, we can drop most of the fields we were querying before.

Note that I was hitting some transient issues with my local development setup, so it's possible that you may need to run `npx gatsby clean` to clear your local cache in order to test this out locally.