### PR TITLE
Update blog post schema

### DIFF
--- a/src/schemas/blog_post.json
+++ b/src/schemas/blog_post.json
@@ -39,38 +39,29 @@
       "type" : "Slices",
       "fieldset" : "Slice zone",
       "config" : {
-        "labels" : {
-          "stats_block" : [ {
-            "display" : "stats label",
-            "name" : "stats_label"
-          }, {
-            "display" : "stats number",
-            "name" : "stats_number"
-          } ]
-        },
+        "labels" : null,
         "choices" : {
           "stats_block" : {
             "type" : "Slice",
             "fieldset" : "Stats Block",
-            "description" : "Displays some statistics",
+            "description" : "A short text block that highlights a statistic.",
             "icon" : "equalizer",
             "display" : "list",
-            "non-repeat" : { },
-            "repeat" : { }
-          },
-          "text" : {
-            "type" : "Slice",
-            "fieldset" : "Text",
-            "description" : "A rich text section",
-            "icon" : "text_fields",
             "non-repeat" : {
-              "text" : {
+              "statistic" : {
                 "type" : "StructuredText",
                 "config" : {
-                  "multi" : "paragraph,preformatted,heading2,heading3,strong,em,hyperlink,embed,list-item,o-list-item,o-list-item",
-                  "allowTargetBlank" : true,
-                  "label" : "Text",
-                  "placeholder" : "Post text..."
+                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label" : "Statistic Highlight",
+                  "placeholder" : "9,000"
+                }
+              },
+              "statistic_text" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "paragraph",
+                  "label" : "Statistic text",
+                  "placeholder" : "At-risk community members can now access service and ammenities"
                 }
               }
             },
@@ -78,9 +69,10 @@
           },
           "image_with_caption" : {
             "type" : "Slice",
-            "fieldset" : "Image with Caption",
+            "fieldset" : "Image Block",
             "description" : "An image with an optional caption",
             "icon" : "image",
+            "display" : "list",
             "non-repeat" : {
               "image" : {
                 "type" : "Image",
@@ -98,6 +90,128 @@
                   "single" : "heading3",
                   "label" : "Caption",
                   "placeholder" : "Image Caption..."
+                }
+              }
+            },
+            "repeat" : { }
+          },
+          "text_block" : {
+            "type" : "Slice",
+            "fieldset" : "Text Block",
+            "description" : "A block of text with an optional header.",
+            "icon" : "text_fields",
+            "display" : "list",
+            "non-repeat" : {
+              "header" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label" : "Header",
+                  "placeholder" : "Header Text (optional)"
+                }
+              },
+              "body_text" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "paragraph,preformatted,heading6,strong,em,hyperlink,embed,list-item,o-list-item,rtl",
+                  "allowTargetBlank" : true,
+                  "label" : "Body Text",
+                  "placeholder" : "Add your rich text here."
+                }
+              }
+            },
+            "repeat" : { }
+          },
+          "file_download_block" : {
+            "type" : "Slice",
+            "fieldset" : "Download CTA Block",
+            "description" : "A CTA button block that downloads a file.",
+            "icon" : "file_download",
+            "display" : "list",
+            "non-repeat" : {
+              "file_download_header" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label" : "File Download Header",
+                  "placeholder" : "Download our annual report"
+                }
+              },
+              "file" : {
+                "type" : "Link",
+                "config" : {
+                  "select" : "media",
+                  "label" : "File",
+                  "placeholder" : "The file to download on button click."
+                }
+              }
+            },
+            "repeat" : { }
+          },
+          "cta_block" : {
+            "type" : "Slice",
+            "fieldset" : "CTA Block",
+            "description" : "A CTA button block that opens a web page.",
+            "icon" : "link",
+            "display" : "list",
+            "non-repeat" : {
+              "header" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label" : "Header",
+                  "placeholder" : "Sign up for our newsletter and community events!"
+                }
+              },
+              "button_text" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "paragraph",
+                  "label" : "Button Text",
+                  "placeholder" : "Sign Up"
+                }
+              },
+              "button_link" : {
+                "type" : "Link",
+                "config" : {
+                  "label" : "Button LInk",
+                  "select" : null
+                }
+              }
+            },
+            "repeat" : { }
+          },
+          "separator" : {
+            "type" : "Slice",
+            "fieldset" : "Separator",
+            "description" : "A horizontal rule for dividing content.",
+            "icon" : "remove",
+            "display" : "list",
+            "non-repeat" : {
+              "separator_image" : {
+                "type" : "Image",
+                "config" : {
+                  "constraint" : { },
+                  "thumbnails" : [ ],
+                  "label" : "Separator Image"
+                }
+              }
+            },
+            "repeat" : { }
+          },
+          "quote_block" : {
+            "type" : "Slice",
+            "fieldset" : "Quote Block",
+            "description" : "Displays a quote in its own block.",
+            "icon" : "format_quote",
+            "display" : "list",
+            "non-repeat" : {
+              "quote" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "heading5",
+                  "label" : "Quote",
+                  "placeholder" : "This is a great quote. - Anonymous"
                 }
               }
             },

--- a/src/schemas/blog_post.json
+++ b/src/schemas/blog_post.json
@@ -1,221 +1,229 @@
 {
-  "Main" : {
-    "title" : {
-      "type" : "StructuredText",
-      "config" : {
-        "single" : "heading1",
-        "label" : "Title"
+  "Main": {
+    "title": {
+      "type": "StructuredText",
+      "config": {
+        "single": "heading1",
+        "label": "Title"
       }
     },
-    "subtitle" : {
-      "type" : "StructuredText",
-      "config" : {
-        "single" : "heading1",
-        "label" : "subtitle"
+    "subtitle": {
+      "type": "StructuredText",
+      "config": {
+        "single": "heading1",
+        "label": "subtitle"
       }
     },
-    "publish_date" : {
-      "type" : "Date",
-      "config" : {
-        "label" : "publish date"
+    "publish_date": {
+      "type": "Date",
+      "config": {
+        "label": "publish date"
       }
     },
-    "header_image" : {
-      "type" : "Image",
-      "config" : {
-        "constraint" : { },
-        "thumbnails" : [ ],
-        "label" : "header image"
+    "header_image": {
+      "type": "Image",
+      "config": {
+        "constraint": {},
+        "thumbnails": [],
+        "label": "header image"
       }
     },
-    "author" : {
-      "type" : "StructuredText",
-      "config" : {
-        "single" : "paragraph",
-        "label" : "author"
+    "author": {
+      "type": "StructuredText",
+      "config": {
+        "single": "paragraph",
+        "label": "author"
       }
     },
-    "body" : {
-      "type" : "Slices",
-      "fieldset" : "Slice zone",
-      "config" : {
-        "labels" : null,
-        "choices" : {
-          "stats_block" : {
-            "type" : "Slice",
-            "fieldset" : "Stats Block",
-            "description" : "A short text block that highlights a statistic.",
-            "icon" : "equalizer",
-            "display" : "list",
-            "non-repeat" : {
-              "statistic" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
-                  "label" : "Statistic Highlight",
-                  "placeholder" : "9,000"
+    "body": {
+      "type": "Slices",
+      "fieldset": "Slice zone",
+      "config": {
+        "labels": null,
+        "choices": {
+          "stats_block": {
+            "type": "Slice",
+            "fieldset": "Stats Block",
+            "description": "A short text block that highlights a statistic.",
+            "icon": "equalizer",
+            "display": "list",
+            "non-repeat": {
+              "statistic": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label": "Statistic Highlight",
+                  "placeholder": "9,000"
                 }
               },
-              "statistic_text" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "single" : "paragraph",
-                  "label" : "Statistic text",
-                  "placeholder" : "At-risk community members can now access service and ammenities"
+              "statistic_text": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph",
+                  "label": "Statistic text",
+                  "placeholder": "At-risk community members can now access service and ammenities"
                 }
               }
             },
-            "repeat" : { }
+            "repeat": {}
           },
-          "image_with_caption" : {
-            "type" : "Slice",
-            "fieldset" : "Image Block",
-            "description" : "An image with an optional caption",
-            "icon" : "image",
-            "display" : "list",
-            "non-repeat" : {
-              "image" : {
-                "type" : "Image",
-                "config" : {
-                  "constraint" : {
-                    "width" : 1200
+          "image_with_caption": {
+            "type": "Slice",
+            "fieldset": "Image Block",
+            "description": "An image with an optional caption",
+            "icon": "image",
+            "display": "list",
+            "non-repeat": {
+              "image": {
+                "type": "Image",
+                "config": {
+                  "constraint": {
+                    "width": 1200
                   },
-                  "thumbnails" : [ ],
-                  "label" : "Image"
+                  "thumbnails": [],
+                  "label": "Image"
                 }
               },
-              "caption" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "single" : "heading3",
-                  "label" : "Caption",
-                  "placeholder" : "Image Caption..."
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "heading3",
+                  "label": "Caption",
+                  "placeholder": "Image Caption..."
                 }
               }
             },
-            "repeat" : { }
+            "repeat": {}
           },
-          "text_block" : {
-            "type" : "Slice",
-            "fieldset" : "Text Block",
-            "description" : "A block of text with an optional header.",
-            "icon" : "text_fields",
-            "display" : "list",
-            "non-repeat" : {
-              "header" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
-                  "label" : "Header",
-                  "placeholder" : "Header Text (optional)"
+          "text_block": {
+            "type": "Slice",
+            "fieldset": "Text Block",
+            "description": "A block of text with an optional header.",
+            "icon": "text_fields",
+            "display": "list",
+            "non-repeat": {
+              "body_text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph, preformatted, heading1, heading2, heading3, heading4, heading5, heading6, strong, em, hyperlink, embed, list-item, o-list-item, rtl",
+                  "allowTargetBlank": true,
+                  "label": "Body Text",
+                  "placeholder": "Add your rich text here."
+                }
+              }
+            },
+            "repeat": {}
+          },
+          "file_download_block": {
+            "type": "Slice",
+            "fieldset": "Download CTA Block",
+            "description": "A CTA button block that downloads a file.",
+            "icon": "file_download",
+            "display": "list",
+            "non-repeat": {
+              "file_download_header": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label": "File Download Header",
+                  "placeholder": "Download our annual report"
                 }
               },
-              "body_text" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "multi" : "paragraph,preformatted,heading6,strong,em,hyperlink,embed,list-item,o-list-item,rtl",
-                  "allowTargetBlank" : true,
-                  "label" : "Body Text",
-                  "placeholder" : "Add your rich text here."
-                }
-              }
-            },
-            "repeat" : { }
-          },
-          "file_download_block" : {
-            "type" : "Slice",
-            "fieldset" : "Download CTA Block",
-            "description" : "A CTA button block that downloads a file.",
-            "icon" : "file_download",
-            "display" : "list",
-            "non-repeat" : {
-              "file_download_header" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
-                  "label" : "File Download Header",
-                  "placeholder" : "Download our annual report"
+              "file": {
+                "type": "Link",
+                "config": {
+                  "select": "media",
+                  "label": "File",
+                  "placeholder": "The file to download on button click."
                 }
               },
-              "file" : {
-                "type" : "Link",
-                "config" : {
-                  "select" : "media",
-                  "label" : "File",
-                  "placeholder" : "The file to download on button click."
+              "button_text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph",
+                  "label": "Button Text",
+                  "placeholder": "Download - 6.2 MB PDF"
                 }
               }
             },
-            "repeat" : { }
+            "repeat": {}
           },
-          "cta_block" : {
-            "type" : "Slice",
-            "fieldset" : "CTA Block",
-            "description" : "A CTA button block that opens a web page.",
-            "icon" : "link",
-            "display" : "list",
-            "non-repeat" : {
-              "header" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
-                  "label" : "Header",
-                  "placeholder" : "Sign up for our newsletter and community events!"
+          "cta_block": {
+            "type": "Slice",
+            "fieldset": "CTA Block",
+            "description": "A CTA button block that opens a web page.",
+            "icon": "link",
+            "display": "list",
+            "non-repeat": {
+              "header": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label": "Header",
+                  "placeholder": "Sign up for our newsletter and community events!"
                 }
               },
-              "button_text" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "multi" : "paragraph",
-                  "label" : "Button Text",
-                  "placeholder" : "Sign Up"
+              "button_text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph",
+                  "label": "Button Text",
+                  "placeholder": "Sign Up"
                 }
               },
-              "button_link" : {
-                "type" : "Link",
-                "config" : {
-                  "label" : "Button LInk",
-                  "select" : null
+              "button_link": {
+                "type": "Link",
+                "config": {
+                  "label": "Button LInk",
+                  "select": null
                 }
               }
             },
-            "repeat" : { }
+            "repeat": {}
           },
-          "separator" : {
-            "type" : "Slice",
-            "fieldset" : "Separator",
-            "description" : "A horizontal rule for dividing content.",
-            "icon" : "remove",
-            "display" : "list",
-            "non-repeat" : {
-              "separator_image" : {
-                "type" : "Image",
-                "config" : {
-                  "constraint" : { },
-                  "thumbnails" : [ ],
-                  "label" : "Separator Image"
+          "separator": {
+            "type": "Slice",
+            "fieldset": "Separator",
+            "description": "A horizontal rule for dividing content.",
+            "icon": "remove",
+            "display": "list",
+            "non-repeat": {
+              "separator_image": {
+                "type": "Image",
+                "config": {
+                  "constraint": {},
+                  "thumbnails": [],
+                  "label": "Separator Image"
                 }
               }
             },
-            "repeat" : { }
+            "repeat": {}
           },
-          "quote_block" : {
-            "type" : "Slice",
-            "fieldset" : "Quote Block",
-            "description" : "Displays a quote in its own block.",
-            "icon" : "format_quote",
-            "display" : "list",
-            "non-repeat" : {
-              "quote" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "multi" : "heading5",
-                  "label" : "Quote",
-                  "placeholder" : "This is a great quote. - Anonymous"
+          "quote_block": {
+            "type": "Slice",
+            "fieldset": "Quote Block",
+            "description": "Displays a quote in its own block.",
+            "icon": "format_quote",
+            "display": "list",
+            "non-repeat": {
+              "quote": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "heading5",
+                  "label": "Quote",
+                  "placeholder": "To be, or not to be? That is the question."
+                }
+              },
+              "attributee": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "heading6",
+                  "label": "Attributee",
+                  "placeholder": "Shakespeare"
                 }
               }
             },
-            "repeat" : { }
+            "repeat": {}
           }
         }
       }


### PR DESCRIPTION
## Description

Closes #276

This is a weird PR, because the actual diffs aren't the most interesting part. All I'm doing code-wise is updating the schema to match the new schema generated by Prismic, based on the Prismic changes I just made. But this does give me a useful platform via which to discuss those changes.

I added some slices to the `Blog Post` type, modeled off of what's in [the current mockup](https://www.figma.com/file/kKaWvJvyzhNS9hD21v7Ei5/ShelterTech.org-2020?node-id=4579%3A6028). I wanted to be able to capture everything in that sample blog post, but the approach I used certainly isn't the only possible one. This might be easiest to review if you take a look at the current state of the `Blog Post` type in Prismic (l[ink here](https://sheltertech.prismic.io/masks/blog_post.json/)). But I'll also use this space to give a run down of my thoughts on each slice:

- **Stats block**: fairly straightforward. Two fields -- one for the "stat" and one for supplementary text.
- **Image block**: also straightforward -- contains an image field and a caption text field.
- **Text block**: contains an optional header and a rich text field. The header part isn't strictly necessary, since those can also be inserted via rich text, but I think it gives us a little more control/consistency to format it like this (especially if we also disable headers in the rich text field, which is possible). This does mean, however, that in some places consecutive text blocks would be necessary, which might(?) not feel intuitive to content creators. I'm not married to this approach and am open to input here.
- **Download CTA block**: right now this only has a header text field and a link for the downloadable file. I imagined we could derive the actual button text (eg. "Download - 1.3 MB PDF") via javascript, so content creators wouldn't have to count megabytes or worry about putting typos here. But if that ends up being too messy and/or not flexible enough, the button text could simply come from a text field.
- **CTA block**: Unlike the download link, the header, button text, and button link are all separate fields here. Also, the example of this block given in the mockup is for a "join our newsletter" CTA at the bottom of the page, which we could  potentially stick at the bottom of _every_ blog post in the actual page logic...but even if we do that, I can think of other contexts in which we might want a CTA in the middle of a post, so I think there's no harm in implementing this as a slice.
- **Quote block**: a very simple block with one text field. Potentially we could do two text fields here ("quote" and "attributee"??), so that we have the ability to style them differently (like say, the person's name may be in italics, or on another line). But right now it's all styled the same, so just having one field is functional. I don't feel strongly either way.
- **Separator:** - this is a weird one. It isn't a content block like the others, but it does look like something we want in a slice, because we want to be able to move it around at will. Right now I made it an image field, which I think covers this use-case fine (and also puts power in the hands of the designers if they ever want to change it).

All of these slices have been implemented and I found it super easy to use them to replicate the mockup blog post in Prismic ([you can see it here](https://sheltertech.prismic.io/documents~b=working&c=unclassified&l=en-us/YQ1b4hAAACAAsTg-/)).

## Testing via GraphQL

No frontend changes have been made, but since this PR updates the graphql schema, the blog post I updated can be queried via the graphiql interface ([http://localhost:8000/___graphql](http://localhost:8000/___graphql)). Navigating all of these nested slices is pretty annoying, but luckily we will only have to build this query once. I don't expect this to be it's final form, and we may add/remove some fields or rename things (or make different choices about `raw` vs `html` vs `text`??), but the following query is a proof-of-concept that fetches the essential info from the current dummy blog post:

```graphql
query MyQuery {
  allPrismicBlogPost {
    edges {
      node {
        id
        data {
          author {
            raw
          }
          header_image {
            alt
            copyright
            url
          }
          title {
            raw
          }
          publish_date
          body {
            ... on PrismicBlogPostDataBodyStatsBlock {
              id
              slice_type
            }
            ... on PrismicBlogPostDataBodyImageWithCaption {
              primary {
                image {
                  url
                  alt
                }
                caption {
                  raw
                }
              }
              slice_type
            }
            ... on PrismicBlogPostDataBodyCtaBlock {
              id
              primary {
                button_link {
                  url
                }
                button_text {
                  raw
                }
                header {
                  raw
                }
              }
              slice_type
            }
            ... on PrismicBlogPostDataBodySeparator {
              id
              primary {
                separator_image {
                  url
                }
              }
              slice_type
            }
            ... on PrismicBlogPostDataBodyQuoteBlock {
              id
              primary {
                quote {
                  raw
                }
              }
              slice_type
            }
            ... on PrismicBlogPostDataBodyTextBlock {
              id
              primary {
                body_text {
                  html
                }
                header {
                  raw
                }
              }
              slice_type
            }
            ... on PrismicBlogPostDataBodyFileDownloadBlock {
              id
              primary {
                file {
                  url
                }
                file_download_header {
                  raw
                }
              }
              slice_type
            }
          }
        }
      }
    }
  }
}
```
If you paste this into your graphiql interface, you should get JSON containing the blog post data (you might need to run `npx gatsby clean` for it to recognize the schema changes). In the returned JSON (which I won't paste here out of consideration for your scrollbar), each slice is an object inside of the `body` array, and they can be differentiated by their `slice_type`. This should make it super simple to write some logic that checks each `slice_type` and passes the appropriate fields to a matching component.

## Next Steps

Once we're happy with the slices, the setup for blog posts will be _mostly_* done on the Prismic side of things, but here are my rough thoughts on what we'll need to do next, in a more or less chronological order:

1. Dynamic routing for blog posts, so that each published Prismic `blog post` is given its own unique url. I don't really know what setting that up will entail with Gatsby involved -- @richardxia, do you know?
2. (Optional?) We'll need to configure our prismic previews to work with dynamic pages, because they cannot currently do that. This doesn't block the other work, since none of this is public, so preview functionality isn't essential.
3. Initial frontend "template" page for blog posts, which would all share the same basic styling (is that "spotlight" block at the bottom a fixed part of the page?) and perform a query like the one above (but based on ID) to fetch the blog post content. As a simple starter, it might be enough to just print the JSON response directly onto the page.
4. Building components for each slice, and then writing logic within the above template page that parses the JSON and passes it to the new components. I think it'd be nice to have this step be done all in one go (so we could look at that parsing logic holistically)...but to keep the work simple, maybe they could be very basic, unstyled components at this point.
5. Once all of the structure is in place, we could go over each component more carefully and style everything

*Another piece of Prismic-side setup we should think about is blog categories, which we'll need in place before we can make the blog landing page (unless we scope that down). I'm thinking we'll want a repeatable type `Blog Category` and then we can make instances for each actual category ("ShelterConnect", "SFServiceGuide", etc), so that they can be linked to the individual blog posts in a one-to-many relationship. But I'm not sure if the categories in the mockup are the actual final ones we intend to use, and while this is probably a blocker to release, it certainly isn't blocking any near-term work, so I'm not overly concerned about it.

## How to review this PR??

Since the code diffs aren't super useful, I think normal discussion is probably more helpful here. Does the way I organized the slices make sense? Is there anything I've failed to consider? How do my thoughts look for our next steps? -- I think stuff like that is what we should focus on here.

Please let me know if there's anything I can clarify!