### PR TITLE
Add dynamic page for blog posts

### DIFF
--- a/src/pages/blog/BlogPostTemplate/blogPostTemplate.tsx
+++ b/src/pages/blog/BlogPostTemplate/blogPostTemplate.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+type BlogPostTemplateProps = {
+  title: String;
+  author: String;
+};
+
+/** The JSX template we render for each blog post. */
+const BlogPostTemplate = ({ title, author }: BlogPostTemplateProps) => {
+  return (
+    <div>
+      <h1>{title}</h1>
+      <p>{author}</p>
+    </div>
+  );
+};
+
+export default BlogPostTemplate;

--- a/src/pages/blog/BlogPostTemplate/index.ts
+++ b/src/pages/blog/BlogPostTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./blogPostTemplate";

--- a/src/pages/blog/{prismicBlogPost.uid}.tsx
+++ b/src/pages/blog/{prismicBlogPost.uid}.tsx
@@ -1,0 +1,120 @@
+import { graphql, PageProps } from "gatsby";
+import React from "react";
+import BlogPostTemplate from "./BlogPostTemplate";
+
+/**
+  This is the setup for our dynamically generated blog post pages.
+  All urls of the pattern "/blog/{uid}"" point here and perform the query on this page.
+  Refer to the following docs:
+  https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/
+  https://prismic.io/docs/technologies/tutorial-4-add-dynamic-pages-gatsby
+*/
+
+export const query = graphql`
+  query PrismicBlogPost($uid: String!) {
+    prismicBlogPost(uid: { eq: $uid }) {
+      data {
+        author {
+          text
+        }
+        header_image {
+          alt
+          copyright
+          url
+        }
+        title {
+          text
+        }
+        publish_date
+        body {
+          ... on PrismicBlogPostDataBodyStatsBlock {
+            id
+            slice_type
+          }
+          ... on PrismicBlogPostDataBodyImageWithCaption {
+            primary {
+              image {
+                url
+                alt
+              }
+              caption {
+                raw
+              }
+            }
+            slice_type
+          }
+          ... on PrismicBlogPostDataBodyCtaBlock {
+            id
+            primary {
+              button_link {
+                url
+              }
+              button_text {
+                text
+              }
+              header {
+                text
+              }
+            }
+            slice_type
+          }
+          ... on PrismicBlogPostDataBodySeparator {
+            id
+            primary {
+              separator_image {
+                url
+              }
+            }
+            slice_type
+          }
+          ... on PrismicBlogPostDataBodyQuoteBlock {
+            id
+            primary {
+              quote {
+                text
+              }
+            }
+            slice_type
+          }
+          ... on PrismicBlogPostDataBodyTextBlock {
+            id
+            primary {
+              body_text {
+                html
+              }
+            }
+            slice_type
+          }
+          ... on PrismicBlogPostDataBodyFileDownloadBlock {
+            id
+            primary {
+              file {
+                url
+              }
+              file_download_header {
+                text
+              }
+            }
+            slice_type
+          }
+        }
+      }
+    }
+  }
+`;
+
+const PrismicBlogPostPage = ({
+  data,
+}: PageProps<GatsbyTypes.PrismicBlogPostQuery>) => {
+  if (!data?.prismicBlogPost?.data) return <h1>There was a problem</h1>;
+  const blogData = data.prismicBlogPost.data;
+
+  return (
+    <BlogPostTemplate
+      title={blogData?.title?.text || ""}
+      author={blogData?.author?.text || ""}
+    />
+  );
+};
+
+export default PrismicBlogPostPage;

--- a/src/schemas/blog_post.json
+++ b/src/schemas/blog_post.json
@@ -1,229 +1,236 @@
 {
-  "Main": {
-    "title": {
-      "type": "StructuredText",
-      "config": {
-        "single": "heading1",
-        "label": "Title"
+  "Main" : {
+    "title" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "heading1",
+        "label" : "Title"
       }
     },
-    "subtitle": {
-      "type": "StructuredText",
-      "config": {
-        "single": "heading1",
-        "label": "subtitle"
+    "subtitle" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "heading1",
+        "label" : "subtitle"
       }
     },
-    "publish_date": {
-      "type": "Date",
-      "config": {
-        "label": "publish date"
+    "publish_date" : {
+      "type" : "Date",
+      "config" : {
+        "label" : "publish date"
       }
     },
-    "header_image": {
-      "type": "Image",
-      "config": {
-        "constraint": {},
-        "thumbnails": [],
-        "label": "header image"
+    "uid" : {
+      "type" : "UID",
+      "config" : {
+        "label" : "slug",
+        "placeholder" : "Unique slug used in the URL, ie. \"my-cool-blog-post\""
       }
     },
-    "author": {
-      "type": "StructuredText",
-      "config": {
-        "single": "paragraph",
-        "label": "author"
+    "header_image" : {
+      "type" : "Image",
+      "config" : {
+        "constraint" : { },
+        "thumbnails" : [ ],
+        "label" : "header image"
       }
     },
-    "body": {
-      "type": "Slices",
-      "fieldset": "Slice zone",
-      "config": {
-        "labels": null,
-        "choices": {
-          "stats_block": {
-            "type": "Slice",
-            "fieldset": "Stats Block",
-            "description": "A short text block that highlights a statistic.",
-            "icon": "equalizer",
-            "display": "list",
-            "non-repeat": {
-              "statistic": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "heading1,heading2,heading3,heading4,heading5,heading6",
-                  "label": "Statistic Highlight",
-                  "placeholder": "9,000"
+    "author" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "paragraph",
+        "label" : "author"
+      }
+    },
+    "body" : {
+      "type" : "Slices",
+      "fieldset" : "Slice zone",
+      "config" : {
+        "labels" : null,
+        "choices" : {
+          "stats_block" : {
+            "type" : "Slice",
+            "fieldset" : "Stats Block",
+            "description" : "A short text block that highlights a statistic.",
+            "icon" : "equalizer",
+            "display" : "list",
+            "non-repeat" : {
+              "statistic" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label" : "Statistic Highlight",
+                  "placeholder" : "9,000"
                 }
               },
-              "statistic_text": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "paragraph",
-                  "label": "Statistic text",
-                  "placeholder": "At-risk community members can now access service and ammenities"
+              "statistic_text" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "paragraph",
+                  "label" : "Statistic text",
+                  "placeholder" : "At-risk community members can now access service and ammenities"
                 }
               }
             },
-            "repeat": {}
+            "repeat" : { }
           },
-          "image_with_caption": {
-            "type": "Slice",
-            "fieldset": "Image Block",
-            "description": "An image with an optional caption",
-            "icon": "image",
-            "display": "list",
-            "non-repeat": {
-              "image": {
-                "type": "Image",
-                "config": {
-                  "constraint": {
-                    "width": 1200
+          "image_with_caption" : {
+            "type" : "Slice",
+            "fieldset" : "Image Block",
+            "description" : "An image with an optional caption",
+            "icon" : "image",
+            "display" : "list",
+            "non-repeat" : {
+              "image" : {
+                "type" : "Image",
+                "config" : {
+                  "constraint" : {
+                    "width" : 1200
                   },
-                  "thumbnails": [],
-                  "label": "Image"
+                  "thumbnails" : [ ],
+                  "label" : "Image"
                 }
               },
-              "caption": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "heading3",
-                  "label": "Caption",
-                  "placeholder": "Image Caption..."
+              "caption" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading3",
+                  "label" : "Caption",
+                  "placeholder" : "Image Caption..."
                 }
               }
             },
-            "repeat": {}
+            "repeat" : { }
           },
-          "text_block": {
-            "type": "Slice",
-            "fieldset": "Text Block",
-            "description": "A block of text with an optional header.",
-            "icon": "text_fields",
-            "display": "list",
-            "non-repeat": {
-              "body_text": {
-                "type": "StructuredText",
-                "config": {
-                  "multi": "paragraph, preformatted, heading1, heading2, heading3, heading4, heading5, heading6, strong, em, hyperlink, embed, list-item, o-list-item, rtl",
-                  "allowTargetBlank": true,
-                  "label": "Body Text",
-                  "placeholder": "Add your rich text here."
+          "text_block" : {
+            "type" : "Slice",
+            "fieldset" : "Text Block",
+            "description" : "A block of text with an optional header.",
+            "icon" : "text_fields",
+            "display" : "list",
+            "non-repeat" : {
+              "body_text" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,embed,list-item,o-list-item,rtl",
+                  "allowTargetBlank" : true,
+                  "label" : "Body Text",
+                  "placeholder" : "Add your rich text here."
                 }
               }
             },
-            "repeat": {}
+            "repeat" : { }
           },
-          "file_download_block": {
-            "type": "Slice",
-            "fieldset": "Download CTA Block",
-            "description": "A CTA button block that downloads a file.",
-            "icon": "file_download",
-            "display": "list",
-            "non-repeat": {
-              "file_download_header": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "heading1,heading2,heading3,heading4,heading5,heading6",
-                  "label": "File Download Header",
-                  "placeholder": "Download our annual report"
+          "file_download_block" : {
+            "type" : "Slice",
+            "fieldset" : "Download CTA Block",
+            "description" : "A CTA button block that downloads a file.",
+            "icon" : "file_download",
+            "display" : "list",
+            "non-repeat" : {
+              "file_download_header" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label" : "File Download Header",
+                  "placeholder" : "Download our annual report"
                 }
               },
-              "file": {
-                "type": "Link",
-                "config": {
-                  "select": "media",
-                  "label": "File",
-                  "placeholder": "The file to download on button click."
+              "file" : {
+                "type" : "Link",
+                "config" : {
+                  "select" : "media",
+                  "label" : "File",
+                  "placeholder" : "The file to download on button click."
                 }
               },
-              "button_text": {
-                "type": "StructuredText",
-                "config": {
-                  "multi": "paragraph",
-                  "label": "Button Text",
-                  "placeholder": "Download - 6.2 MB PDF"
+              "button_text" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "paragraph",
+                  "label" : "Button Text",
+                  "placeholder" : "Download - 6.2 MB PDF"
                 }
               }
             },
-            "repeat": {}
+            "repeat" : { }
           },
-          "cta_block": {
-            "type": "Slice",
-            "fieldset": "CTA Block",
-            "description": "A CTA button block that opens a web page.",
-            "icon": "link",
-            "display": "list",
-            "non-repeat": {
-              "header": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "heading1,heading2,heading3,heading4,heading5,heading6",
-                  "label": "Header",
-                  "placeholder": "Sign up for our newsletter and community events!"
+          "cta_block" : {
+            "type" : "Slice",
+            "fieldset" : "CTA Block",
+            "description" : "A CTA button block that opens a web page.",
+            "icon" : "link",
+            "display" : "list",
+            "non-repeat" : {
+              "header" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading1,heading2,heading3,heading4,heading5,heading6",
+                  "label" : "Header",
+                  "placeholder" : "Sign up for our newsletter and community events!"
                 }
               },
-              "button_text": {
-                "type": "StructuredText",
-                "config": {
-                  "multi": "paragraph",
-                  "label": "Button Text",
-                  "placeholder": "Sign Up"
+              "button_text" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "paragraph",
+                  "label" : "Button Text",
+                  "placeholder" : "Sign Up"
                 }
               },
-              "button_link": {
-                "type": "Link",
-                "config": {
-                  "label": "Button LInk",
-                  "select": null
+              "button_link" : {
+                "type" : "Link",
+                "config" : {
+                  "label" : "Button LInk",
+                  "select" : null
                 }
               }
             },
-            "repeat": {}
+            "repeat" : { }
           },
-          "separator": {
-            "type": "Slice",
-            "fieldset": "Separator",
-            "description": "A horizontal rule for dividing content.",
-            "icon": "remove",
-            "display": "list",
-            "non-repeat": {
-              "separator_image": {
-                "type": "Image",
-                "config": {
-                  "constraint": {},
-                  "thumbnails": [],
-                  "label": "Separator Image"
+          "separator" : {
+            "type" : "Slice",
+            "fieldset" : "Separator",
+            "description" : "A horizontal rule for dividing content.",
+            "icon" : "remove",
+            "display" : "list",
+            "non-repeat" : {
+              "separator_image" : {
+                "type" : "Image",
+                "config" : {
+                  "constraint" : { },
+                  "thumbnails" : [ ],
+                  "label" : "Separator Image"
                 }
               }
             },
-            "repeat": {}
+            "repeat" : { }
           },
-          "quote_block": {
-            "type": "Slice",
-            "fieldset": "Quote Block",
-            "description": "Displays a quote in its own block.",
-            "icon": "format_quote",
-            "display": "list",
-            "non-repeat": {
-              "quote": {
-                "type": "StructuredText",
-                "config": {
-                  "multi": "heading5",
-                  "label": "Quote",
-                  "placeholder": "To be, or not to be? That is the question."
+          "quote_block" : {
+            "type" : "Slice",
+            "fieldset" : "Quote Block",
+            "description" : "Displays a quote in its own block.",
+            "icon" : "format_quote",
+            "display" : "list",
+            "non-repeat" : {
+              "quote" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "heading5",
+                  "label" : "Quote",
+                  "placeholder" : "To be, or not to be? That is the question."
                 }
               },
-              "attributee": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "heading6",
-                  "label": "Attributee",
-                  "placeholder": "Shakespeare"
+              "attributee" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading6",
+                  "label" : "Attributee",
+                  "placeholder" : "Shakespeare"
                 }
               }
             },
-            "repeat": {}
+            "repeat" : { }
           }
         }
       }


### PR DESCRIPTION
## Description

Closes #293 

Adds the dynamic route `/blog/{slug}` for our blog posts (where `slug` is our label for the Prismic `uid` field). If you were to check this out locally, both http://localhost:8000/blog/mission-hotel-free-internet/ and http://localhost:8000/blog/cool-blog-post should render pages with their respective blog titles and authors.

This PR doesn't put all the blog content on the page, nor does it style it -- I only added enough JSX for a proof of concept. I did make the decision to break the JSX out into its own component (`<BlogPostTemplate />`), because the query in `src/pages/blog/{prismicBlogPost.uid}.tsx ` is very long, so I felt one or the other should live in a different file.

## Notes
- If you add a new blog post in Prismic, or change the slug on an existing blog post, you'll need to restart Gatsby to be able to see it locally
- [The Prismic docs](https://prismic.io/docs/core-concepts/uid) _say_ they keep a history of old uids/slugs, so old ones should still direct to the right page, but I couldn't get this to work. If you want to test for yourself, http://localhost:8000/blog/cool-blog-post used to be http://localhost:8000/blog/test-blog-post -- my understanding is that both of these should work, but right now only the newer one works. I tried Googling it and saw a lot of other people going to Prismic support with questions about this, so it might not be a very stable feature...

## Open Questions
- What do we want to do when the query fails/doesn't return anything? Should we redirect to the 404 page?
- Prismic doesn't allow us to make fields required, but there are some that we probably _do_ want to have present (ie "title", "author"). What should we do if these return empty? Should we fail loudly, or quietly in these cases?