### PR TITLE
Update remaining copy changes on the Volunteer Page.

### DIFF
--- a/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
+++ b/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
@@ -163,6 +163,16 @@
   margin-bottom: -142px;
 }
 
+/* TODO: These styles work around a few global styles from the legacy site.
+ * We may need to revisit how these are styled after removing the legacy site's
+ * CSS reset.
+ */
+.paragraph1Wrapper ul,
+.paragraph2Wrapper ul {
+  list-style: disc;
+  padding-left: 1.5em;
+}
+
 @media (--tablet-and-down) {
   .paragraph1Wrapper {
     font: var(--font-body-medium);

--- a/src/pages/volunteer/index.tsx
+++ b/src/pages/volunteer/index.tsx
@@ -4,7 +4,6 @@ import { Helmet } from "react-helmet";
 import ArticleSpotlightCard from "../../components/grid-aware/ArticleSpotlightCard";
 import COVID19infoBoxBlock from "../../components/grid-aware/COVID19InfoBoxBlock";
 import ImageHeader from "../../components/grid-aware/ImageHeader";
-import classroom from "../../components/grid-aware/ImageHeader/stories/classroom.png";
 import whiteboard from "../../components/grid-aware/ImageHeader/stories/whiteboard-sticky-notes.png";
 import Modal from "../../components/grid-aware/Modal";
 import OneParagraphBlock from "../../components/grid-aware/OneParagraphBlock";
@@ -38,10 +37,6 @@ export default () => {
         subtitle="ShelterTech is an all-volunteer organization that relies on volunteers to bridge the digital divide faced by people experiencing homelessness and are housing insecure in San Francisco. Internet access and technology makes it possible for people to find jobs, human services, and contact family and friends."
         description="If you share our belief that digital equity is a human right, we encourage you to apply and work with us."
         image1={{
-          url: classroom,
-          alt: "Classroom of volunteer members collaborating with one another.",
-        }}
-        image2={{
           url: whiteboard,
           alt: "Team members collaborating together by looking and pointing at whiteboard covered with sticky notes full of ideas.",
         }}
@@ -85,14 +80,14 @@ export default () => {
             "Being based out of San Francisco, tech professionals comprise the bulk of our volunteer base and work together to improve the digital infrastructure powering the services designated for underserved residents.",
         }}
         paragraph2={{
-          title: "Partnerships & Communications",
-          description:
-            "We work with government agencies, nonprofits, and local businesses to strengthen the city’s social services ecosystem. via discourse and knowledge sharing between organizations that align with our mission.",
-        }}
-        paragraph3={{
           title: "Research & Community Development",
           description:
             "No two experiences of people facing housing insecurity is the same. We have a dedicated team working alongside individuals who have experienced homelessness learning how best to serve the diverse challenges faced by those facing housing insecurity.",
+        }}
+        paragraph3={{
+          title: "Partnerships & Communications",
+          description:
+            "We work with government agencies, nonprofits, and local businesses to strengthen the city’s social services ecosystem. via discourse and knowledge sharing between organizations that align with our mission.",
         }}
         leftTopImage={{
           url: teamInClassroom,
@@ -114,22 +109,24 @@ export default () => {
         paragraph2={
           <>
             <p>We ask that you consider these three things before joining:</p>
-            <p>
-              &bull; You are willing to volunteer at least three hours each week
-            </p>
-            <p>
-              &bull; You will be kind, considerate, and ethical towards other
-              volunteers and the communities we serve
-            </p>
-            <p>
-              &bull; You understand that ShelterTech is an all-volunteer team,
-              and that you will try your best to always represent ShelterTech in
-              a professional and thoughftul manner.
-            </p>
-            <p>
-              &bull; No matter what role you play, the essential attitude you
-              need is a deep belief in digital equity for all people
-            </p>
+            <ul>
+              <li>
+                You are willing to volunteer at least three hours each week
+              </li>
+              <li>
+                You will be kind, considerate, and ethical towards other
+                volunteers and the communities we serve
+              </li>
+              <li>
+                You understand that ShelterTech is an all-volunteer team, and
+                that you will try your best to always represent ShelterTech in a
+                professional and thoughftul manner
+              </li>
+              <li>
+                No matter what role you play, the essential attitude you need is
+                a deep belief in digital equity for all people
+              </li>
+            </ul>
           </>
         }
         image={{


### PR DESCRIPTION
Resolves the remaining things in #274, which should make all of the copy match the Figma designs.

- Swapped paragraphs 2 and 3 in the "How we work" section.
- Removed stray period in "Volunteering at Sheltertech" section.
- Replaced `&bull;` HTML entity with `<ul>` and `<li>` markup.
- Removed one of the images in the header. (This is one that I had not caught in #274, but that I noticed after doing a final scan between the Figma design and the site)

I think the only thing of note is that in order to remove the `&bull;` HTML entities, I had to add a bit of CSS to the TwoParagraphBlock. In the future, I think two things will change how we want to handle this:

1. We'll eventually remove all the legacy pages, which pull in a pretty large CSS reset stylesheet, which I had to undo in this component. If we end up upgrading or switching CSS reset/normalization stylesheets, then we may need to update this.
2. I imagine that this content will eventually come in the form of a Prismic Rich Text field, which allows non-technical users to create text with a restricted set of HTML elements, including lists. We'll probably want some set of generic styles for Rich Text content that renders these things properly, and this may overlap with the work @jessica-px has been doing to style the blog posts.