### PR TITLE
TwoParagraphBlock: Update styling for Volunteer page variant.

### DIFF
--- a/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
+++ b/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.module.css
@@ -13,9 +13,12 @@
 }
 
 .bleedBackground {
-  background: var(--color-gray-300);
   grid-column: 1 / span 2;
   grid-row: 1;
+}
+
+.bleedBackground.gray {
+  background: var(--color-gray-300);
 }
 
 .bleedMainContent {
@@ -40,16 +43,9 @@
   column-gap: var(--grid-column-gap);
   display: grid;
   grid-template-columns: repeat(var(--grid-column-count), minmax(0, 1fr));
-  grid-template-rows: auto minmax(590px, auto);
-  padding-top: 140px;
-}
-
-.gridParentAbout {
-  column-gap: var(--grid-column-gap);
-  display: grid;
-  grid-template-columns: repeat(var(--grid-column-count), minmax(0, 1fr));
-  grid-template-rows: auto minmax(492px, auto);
-  padding-top: 140px;
+  grid-template-rows: auto minmax(0, 1fr);
+  padding-bottom: 120px;
+  padding-top: 120px;
 }
 
 .gridParent > * {
@@ -60,11 +56,6 @@
   .gridParent {
     display: block;
     padding: 50px 0 80px;
-  }
-
-  .gridParentAbout {
-    display: block;
-    padding: 50px 0;
   }
 }
 
@@ -87,14 +78,9 @@
   margin-top: 70px;
 }
 
-.gridAreaParagraph2About {
-  padding-right: 16px;
-}
-
 .gridAreaImage {
   grid-column: 8 / span 4;
-  grid-row: 2;
-  margin-top: 15px;
+  grid-row: 1 / span 2;
 }
 
 .gridAreaImageAbout {
@@ -107,10 +93,6 @@
 @media (--tablet-and-down) {
   .gridAreaParagraph2 {
     margin-top: 40px;
-  }
-
-  .gridAreaParagraph2About {
-    padding-right: 0;
   }
 
   .gridAreaImage {
@@ -139,7 +121,7 @@
   font: var(--font-body-small);
 }
 
-.paragraph2WrapperAbout {
+.paragraph2Wrapper.aboutUsPage {
   font: var(--font-body-medium);
 }
 
@@ -147,20 +129,16 @@
   margin: 0;
 }
 
-.paragraph2WrapperAbout :first-child {
-  margin: 0;
-}
-
 .paragraph2Wrapper :not(:first-child) {
   margin-top: 15px;
 }
 
-.paragraph2WrapperAbout :not(:first-child) {
-  margin-top: 15px;
-}
-
-.image1Wrapper {
-  margin-bottom: -142px;
+@media (--laptop-and-up) {
+  .image1Wrapper.aboutUsPage {
+    /* Allows the image to "hang over" the boundary of the component, since the
+     * image will not contribute to the height of its grid row. */
+    height: 0;
+  }
 }
 
 /* TODO: These styles work around a few global styles from the legacy site.
@@ -182,15 +160,6 @@
   .paragraph2Wrapper {
     font: var(--font-body-medium);
     margin-top: 40px;
-  }
-
-  .paragraph2WrapperAbout {
-    font: var(--font-body-medium);
-    margin-top: 40px;
-  }
-
-  .image1Wrapper {
-    margin-bottom: 0;
   }
 }
 

--- a/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.stories.jsx
+++ b/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.stories.jsx
@@ -8,14 +8,24 @@ export default {
   component: TwoParagraphBlock,
 };
 
-const Template = ({ title, paragraph1, paragraph2, image1, ctaButtons }) => (
+const Template = ({
+  title,
+  paragraph1,
+  paragraph2,
+  image,
+  ctaButtons,
+  isAbout,
+  theme,
+}) => (
   <div style={{ border: "1px dashed rebeccapurple" }}>
     <TwoParagraphBlock
       title={title}
       paragraph1={paragraph1}
       paragraph2={paragraph2}
-      image={image1}
+      image={image}
       ctaButtons={ctaButtons}
+      isAbout={isAbout}
+      theme={theme}
     />
   </div>
 );
@@ -42,7 +52,7 @@ Gray.args = {
       </p>
     </>
   ),
-  image1: {
+  image: {
     url: volunteers,
     alt: "Five volunteer members surrounding a table of holiday care packages.",
   },

--- a/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.tsx
+++ b/src/components/grid-aware/TwoParagraphBlock/TwoParagraphBlock.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { ThemeColorOption } from "../../../types";
 import Button, { ButtonProps } from "../../inline/Button";
 
 import * as s from "./TwoParagraphBlock.module.css";
@@ -12,6 +13,7 @@ type TwoParagraphBlockProps = {
   paragraph2?: React.ReactNode;
   image: { url: string; alt: string };
   ctaButtons?: ButtonProps[];
+  theme: ThemeColorOption;
 };
 
 const TwoParagraphBlock = ({
@@ -21,15 +23,10 @@ const TwoParagraphBlock = ({
   paragraph2,
   image,
   ctaButtons,
+  theme,
 }: TwoParagraphBlockProps) => {
-  const gridParent = isAbout ? s.gridParentAbout : s.gridParent;
   const gridAreaImage = isAbout ? s.gridAreaImageAbout : s.gridAreaImage;
-  const paragraph2Wrapper = isAbout
-    ? s.paragraph2WrapperAbout
-    : s.paragraph2Wrapper;
-  const gridAreaParagraph2 = isAbout
-    ? `${s.gridAreaParagraph2} ${s.gridAreaParagraph2About}`
-    : s.gridAreaParagraph2;
+  const aboutUsPageClass = isAbout ? s.aboutUsPage : "";
 
   const GridAreaTitle = () => (
     <div className={s.gridAreaTitle}>
@@ -59,15 +56,17 @@ const TwoParagraphBlock = ({
   );
 
   const GridAreaParagraph2 = () => (
-    <div className={gridAreaParagraph2}>
-      <div className={paragraph2Wrapper}>{paragraph2}</div>
+    <div className={s.gridAreaParagraph2}>
+      <div className={`${s.paragraph2Wrapper} ${aboutUsPageClass}`}>
+        {paragraph2}
+      </div>
       {isCtaButtons}
     </div>
   );
 
   const GridAreaImage = () => (
     <div className={gridAreaImage}>
-      <div className={s.image1Wrapper}>
+      <div className={`${s.image1Wrapper} ${aboutUsPageClass}`}>
         <img className={s.image1} src={image.url} alt={image.alt} />
       </div>
     </div>
@@ -75,11 +74,11 @@ const TwoParagraphBlock = ({
 
   return (
     <div className={s.bleedWrapper}>
-      <div className={s.bleedBackground} />
+      <div className={`${s.bleedBackground} ${s[theme]}`} />
       <div className={s.bleedMainContent}>
-        <section className={gridParent}>
+        <section className={s.gridParent}>
           <GridAreaTitle />
-          <GridAreaParagraph1 />
+          {paragraph1 && <GridAreaParagraph1 />}
           <GridAreaImage />
           <GridAreaParagraph2 />
         </section>

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -93,6 +93,7 @@ export default () => (
         url: darcelJackson,
         alt: "Darcel Jackson, founder of ShelterTech.",
       }}
+      theme="gray"
     />
     <Spacer heightDesktop="190px" heightMobile="80px" />
     <ArticleSpotlightCard

--- a/src/pages/volunteer/index.tsx
+++ b/src/pages/volunteer/index.tsx
@@ -102,7 +102,6 @@ export default () => {
           { text: "Apply", onClick: () => setVolunteerFormIsOpen(true) },
         ]}
       />
-      <Spacer heightDesktop="120px" heightMobile="0" />
       <TwoParagraphBlock
         title="Volunteering at ShelterTech"
         paragraph1=""
@@ -139,6 +138,7 @@ export default () => {
             onClick: () => setVolunteerFormIsOpen(true),
           },
         ]}
+        theme="white"
       />
       <OneParagraphBlock
         title="We need your expertise"


### PR DESCRIPTION
Fixes #271.

The changes include:

- Allow for a white background (via theme prop)
- Making the image span both rows for the Volunteer page variant
- Eliminating the "first paragraph" `<div>` if no paragraph1 is passed in
- Removing unnecessary differences between the Volunteer page and About
  Us page variants of the components

There's still a bit of oddness due to differences in the design between
the About Us and the Volunteer pages, but this isn't adding any further
discrepancies.


Since the CSS for this component is pretty tricky and there are significant differences in styling between the About Us page and Volunteer page versions, I manually checked both pages on both laptop and mobile sized screens, just to make sure there weren't any issues. Here are a few screenshots of what this now looks like:

### About Us
<img width="966" alt="Screen Shot 2022-01-03 at 9 15 19 PM" src="https://user-images.githubusercontent.com/1002748/148012866-e14df033-3fb9-4825-ac5b-2c23b9d99e06.png">

### Volunteer
<img width="791" alt="Screen Shot 2022-01-03 at 9 21 25 PM" src="https://user-images.githubusercontent.com/1002748/148013047-66684653-9ed6-4c73-902c-3fdc0295279f.png">