### PR TITLE
Home Page: Remove black background and spacer.

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -134,18 +134,13 @@ export default () => {
         ]}
         theme="white"
       />
-      <Spacer
-        heightDesktop="91px"
-        heightMobile="19px"
-        color="var(--color-black)"
-      />
+      <Spacer heightDesktop="91px" heightMobile="19px" />
       <VideoSpotlightBlock
         eyebrowText="Our Impact"
         description="Over 1,600 people have daily internet access in local shelters and resource centers."
         button={{ text: "View Annual Report", externalLink: annualReportPDF }}
         imageURL={videoSpotlightBlockImage}
         playButtonOnClick={() => setVideoSpotlightBlockModalIsOpen(true)}
-        blackBackground
       />
       <Spacer heightDesktop="42px" heightMobile="0" />
       <TitleBlock title="What Our Partners Say" />


### PR DESCRIPTION
Just a real quick change, which is I believe the last thing needed to get the site up to parity with the new Figma designs (sans Impact page). Both the spacer and the video spotlight component fortunately have props to control the background color, so I didn't need to change the components themselves, just the Home page.

<img width="1191" alt="Screen Shot 2022-01-03 at 9 26 04 PM" src="https://user-images.githubusercontent.com/1002748/148013516-d19ecfb4-044b-4820-aaa3-f9c7dba52ee3.png">
