### PR TITLE
Remove placeholder Prismic queries

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,4 +1,3 @@
-import { graphql, useStaticQuery } from "gatsby";
 import React, { useState, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import ReactModal from "react-modal";
@@ -39,20 +38,6 @@ const Layout = ({ children }: LayoutProps) => {
     ReactModal.setAppElement(`#${outerContainerID}`);
   }, []);
 
-  const data = useStaticQuery<GatsbyTypes.LayoutQuery>(graphql`
-    query Layout {
-      prismicFooter {
-        data {
-          address {
-            text
-          }
-          sheltertech_logo_link {
-            ...MinimalPrismicLinkData
-          }
-        }
-      }
-    }
-  `);
   return (
     <div id={outerContainerID}>
       <Helmet>
@@ -117,7 +102,6 @@ const Layout = ({ children }: LayoutProps) => {
           shelterTechLogo={{
             url: shelterTechLogoWhite,
             alt: "ShelterTech Logo",
-            link: data.prismicFooter?.data?.sheltertech_logo_link,
           }}
           socialMediaLinks={[
             {
@@ -141,7 +125,7 @@ const Layout = ({ children }: LayoutProps) => {
               alt: "GitHub Logo",
             },
           ]}
-          address={data.prismicFooter?.data?.address?.text}
+          address="268 Bush Street #4302, San Francisco CA, 94104 USA"
           employerIdentificationNumber="EIN: 38-3984099"
         />
       </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,3 @@
-// TODO: Figure out how to get stricter types out of Gatsby GraphQL queries.
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-
-import { graphql, PageProps } from "gatsby";
-import { withPrismicPreview } from "gatsby-plugin-prismic-previews";
 import * as React from "react";
 import { useState } from "react";
 
@@ -28,24 +22,10 @@ import videoSpotlightBlockImage from "../components/grid-aware/VideoSpotlightBlo
 import Layout from "../components/layout";
 import PartnershipSignupForm from "../components/thirdparty/mailchimp/PartnershipSignupForm";
 import partnersAndSponsorsLogos from "../data/partnersAndSponsorsLogos";
-import linkResolver from "../utils/linkResolver";
 import annualReportPDF from "./ShelterTech-Annual-Report-2019-Q1.pdf";
 import articleSpotlightImage from "./images/mission-hotel.jpeg";
 
-export const query = graphql`
-  query HomePage {
-    prismicHomePage {
-      _previewable
-      data {
-        video_header_title {
-          text
-        }
-      }
-    }
-  }
-`;
-
-const IndexPage = ({ data }: PageProps<GatsbyTypes.HomePageQuery>) => {
+export default () => {
   const [partnershipFormIsOpen, setPartnershipFormIsOpen] = useState(false);
   const [videoHeaderModalIsOpen, setVideoHeaderModalIsOpen] = useState(false);
   const [videoSpotlightBlockModalIsOpen, setVideoSpotlightBlockModalIsOpen] =
@@ -82,7 +62,7 @@ const IndexPage = ({ data }: PageProps<GatsbyTypes.HomePageQuery>) => {
         />
       </Modal>
       <VideoHeader
-        title={data.prismicHomePage?.data?.video_header_title?.text}
+        title="Less than half of nearly 28,000 people experiencing homelessness in the Bay Area have reliable access to the internet."
         description="ShelterTech is a technology-focused nonprofit organization making it easier for this community to connect with  resources that can help them address their challenges."
         image={videoHeaderImage}
         ctaButtons={[
@@ -213,10 +193,3 @@ const IndexPage = ({ data }: PageProps<GatsbyTypes.HomePageQuery>) => {
     </Layout>
   );
 };
-
-export default withPrismicPreview(IndexPage, [
-  {
-    repositoryName: "sheltertech",
-    linkResolver,
-  },
-]);


### PR DESCRIPTION
These were initially implemented in order to test out the Prismic
integration with Gatsby and this site. Since we want to initially launch
with just the blog integrated with Prismic, we are removing all the
placeholder queries from the initial development period.

The code being reverted here may still be a useful reference in the
future when we fully integrate the site with Prismic.