### PR TITLE
Add meta tags for blog posts.

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -52,6 +52,7 @@ const Layout = ({ children }: LayoutProps) => {
           name="description"
           content="ShelterTech is solving the biggest technology challenges faced by those experiencing homelessness"
         />
+        <meta name="twitter:site" content="@sheltertechorg" />
         <link rel="icon" href={favicon} />
         {/* Global site tag (gtag.js) - Google Analytics */}
         <script

--- a/src/pages/blog/{prismicBlogPost.uid}.tsx
+++ b/src/pages/blog/{prismicBlogPost.uid}.tsx
@@ -123,6 +123,7 @@ export const query = graphql`
 
 const PrismicBlogPostPage = ({
   data,
+  location,
 }: PageProps<GatsbyTypes.PrismicBlogPostQuery>) => {
   if (!data?.prismicBlogPost?.data) return <h1>There was a problem</h1>;
   const blogData = data.prismicBlogPost.data;
@@ -130,6 +131,7 @@ const PrismicBlogPostPage = ({
 
   return (
     <BlogPostTemplate
+      pageUrl={location.pathname}
       title={blogData?.title?.text}
       author={blogData?.author?.text}
       topic={blogData?.topic?.document?.data?.name?.text}

--- a/src/templates/BlogPostTemplate/blogPostTemplate.tsx
+++ b/src/templates/BlogPostTemplate/blogPostTemplate.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import ButtonBlock from "../../components/blog/ButtonBlock";
 import ImageBlock from "../../components/blog/ImageBlock";
 import LogoSeparator from "../../components/blog/LogoSeparator";
@@ -10,6 +11,9 @@ import Spacer from "../../components/grid-aware/Spacer";
 import Layout from "../../components/layout";
 
 type BlogPostTemplateProps = {
+  // The URL to this page, excluding the domain name. Should start with a
+  // leading "/".
+  pageUrl: string;
   topic?: string;
   title?: string;
   author?: string;
@@ -21,6 +25,7 @@ type BlogPostTemplateProps = {
 
 /** The JSX template we render for each blog post. */
 const BlogPostTemplate = ({
+  pageUrl,
   topic,
   title,
   author,
@@ -100,6 +105,17 @@ const BlogPostTemplate = ({
 
   return (
     <Layout>
+      <Helmet>
+        {title && <title>{title} | ShelterTech</title>}
+        {title && <meta property="og:title" content={title} />}
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={`https://sheltertech.org${pageUrl}`} />
+        <meta
+          name="twitter:card"
+          content={headerImgUrl ? "summary_large_image" : "summary"}
+        />
+        {headerImgUrl && <meta property="og:image" content={headerImgUrl} />}
+      </Helmet>
       <Spacer heightDesktop="80px" heightMobile="50px" />
       <TitleBlock
         topic={topic}


### PR DESCRIPTION
Closes #310.

These are basic tags that mostly follow the guidance from
https://moz.com/blog/meta-data-templates-123

Note that this currently leaves off the `<meta name="description">` and
`<meta property="og:description">` tags. It seems that best practices for
SEO recommend writing a distinct description that's not automatically
generated from the page content itself. This is probably best done as a
separate field in Prismic, which we can do later once the page styling
is done.

It's hard to test this without actually deploying this somewhere real, where I can attempt to link to a page from an actual social media app, but I eyeballed the generated HTML tags and they look about right to me:
<img width="1471" alt="Screen Shot 2022-02-07 at 9 46 08 PM" src="https://user-images.githubusercontent.com/1002748/152926452-0e09bed2-5549-4f77-8a1f-8b0de52be571.png">

Note that `twitter:site` won't show up until we wrap the whole page with `<Layout>`, since I defined it site-wide in that component, but I think that's going to happen very soon when you style the page, @jessica-px.
