### PR TITLE
Replace gatsby-plugin-typegen with built-in Gatsby typegen.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ jspm_packages/
 # gatsby files
 .cache/
 public
-src/__generated__/
+src/gatsby-types.d.ts
 
 # Storybook files
 /storybook-static

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -67,6 +67,12 @@ module.exports = {
         repositoryName: "sheltertech",
       },
     },
-    "gatsby-plugin-typegen",
   ],
+  graphqlTypegen: {
+    // Needed for CI so that the type stubs are available for type checking.
+    // They are otherwise only generated when running a development server, but
+    // it's difficult to start and stop the development server in a CI
+    // environment (hard to know when to send a Ctrl-C to the process in CI).
+    generateOnBuild: true,
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "gatsby-plugin-sass": "^5.25.0",
         "gatsby-plugin-sharp": "^4.25.1",
         "gatsby-plugin-ts-checker": "^1.1.0",
-        "gatsby-plugin-typegen": "^2.2.4",
         "gatsby-source-filesystem": "^4.25.0",
         "gatsby-transformer-sharp": "^4.25.0",
         "identity-obj-proxy": "^3.0.0",
@@ -91,24 +90,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/@ardatan/aggregate-error": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
-      "integrity": "sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@ardatan/aggregate-error/node_modules/tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-      "dev": true
     },
     "node_modules/@aw-web-design/x-default-browser": {
       "version": "1.4.126",
@@ -2286,15 +2267,6 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/@cometjs/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@cometjs/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-H5G7/xYoHxmR4L4Pd77ScRCok2ttz7sG0BZ2B+pzsPammoIE63UiN2bCHjDOkXqbQplWU8xCiJBbHs3Cut2k/g==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.6.5"
-      }
-    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2935,238 +2907,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
-    "node_modules/@graphql-codegen/core": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-1.17.9.tgz",
-      "integrity": "sha512-7nwy+bMWqb0iYJ2DKxA9UiE16meeJ2Ch2XWS/N/ZnA0snTR+GZ20USI8z6YqP1Fuist7LvGO1MbitO2qBT8raA==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^1.18.2",
-        "@graphql-tools/merge": "^6",
-        "@graphql-tools/utils": "^6",
-        "tslib": "~2.0.1"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/@graphql-tools/utils": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.2.4.tgz",
-      "integrity": "sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==",
-      "dev": true,
-      "dependencies": {
-        "@ardatan/aggregate-error": "0.0.6",
-        "camel-case": "4.1.1",
-        "tslib": "~2.0.1"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/camel-case": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
-      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
-      "dev": true,
-      "dependencies": {
-        "pascal-case": "^3.1.1",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/camel-case/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@graphql-codegen/core/node_modules/tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-      "dev": true
-    },
-    "node_modules/@graphql-codegen/flow": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/flow/-/flow-1.18.5.tgz",
-      "integrity": "sha512-0VHG9twylPOlD8aq5lFU2j9K8ueubDwyOm3QYxshmCnjfwPG3xks+zqdTBR/A/jyNrCOPObfycIhotqyoSvn8w==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/flow-operations": {
-      "version": "1.18.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/flow-operations/-/flow-operations-1.18.7.tgz",
-      "integrity": "sha512-yjbKD80erT7y591ZQJGBa5TRymc2mxTd+csFkv+JN+YKiiZXofH4CEs6GaiUq4B8/mg4RpKR/Yrq3AvCyj/c+A==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-codegen/flow": "^1.18.5",
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/flow-operations/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
-    },
-    "node_modules/@graphql-codegen/flow-resolvers": {
-      "version": "1.17.13",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/flow-resolvers/-/flow-resolvers-1.17.13.tgz",
-      "integrity": "sha512-crzdvOBtK0yvb7iXQdx9jBlO+b6+oT1n5DxEeKjZwKqPE/iVy0ooQbX3EoZb7Lci4KuF3DnnssF1Kn469tMRHQ==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-codegen/flow": "^1.18.2",
-        "@graphql-codegen/plugin-helpers": "^1.18.2",
-        "@graphql-codegen/visitor-plugin-common": "^1.17.22",
-        "@graphql-tools/utils": "^7.0.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.0.1"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/flow-resolvers/node_modules/tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-      "dev": true
-    },
-    "node_modules/@graphql-codegen/flow/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
-    },
-    "node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.18.4.tgz",
-      "integrity": "sha512-dpfhUmn9GOS8ByoOPIN3V4Nn9HX7sl9NR7Hf26TgN6Clg7cQvkT6XjHdS2e56Q3kWrxZT1zJ1sEa67D3tj9ZtQ==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/utils": "^7.0.0",
-        "common-tags": "1.8.0",
-        "import-from": "3.0.0",
-        "lodash": "~4.17.20",
-        "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
-    },
-    "node_modules/@graphql-codegen/typescript": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-1.21.1.tgz",
-      "integrity": "sha512-JF6Vsu5HSv3dAoS2ca3PFLUN0qVxotex/+BgWw/6SKhtd83MUPnzJ/RU3lACg4vuNTCWeQSeGvg8x5qrw9Go9w==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations": {
-      "version": "1.17.15",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-1.17.15.tgz",
-      "integrity": "sha512-HStWj3mUe+0ir2J0jqgjegrvcO1DIe2gzsoBBo9RHIYwyaxedUivxXvWY9XBfKpHv6sLa/ST1iYGeedrJELPtw==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/typescript": "^1.21.1",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
-    },
-    "node_modules/@graphql-codegen/typescript-resolvers": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-1.19.0.tgz",
-      "integrity": "sha512-37dkn4f3xcvsMQVatpiL2/r/qpjOyu/HCiJhsZuxLpQaBk7Z+z9nogawt4zxk7ZODpViN1zNO2hS7lLXEGmbZw==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/typescript": "^1.21.1",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "@graphql-tools/utils": "^7.0.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-resolvers/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.19.1.tgz",
-      "integrity": "sha512-MJZXe5vXxV6PLOgHhQoz93gnjzJtbnVQXQKqVEcbyB9W8ImoKuTHsEf/eJ6yCL79f7X/2dnOOM84d5Osh1eaKg==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^1.18.4",
-        "@graphql-tools/optimize": "^1.0.1",
-        "@graphql-tools/relay-operation-optimizer": "^6",
-        "array.prototype.flatmap": "^1.2.4",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.12",
-        "dependency-graph": "^0.11.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
-    },
     "node_modules/@graphql-tools/code-file-loader": {
       "version": "7.3.23",
       "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.23.tgz",
@@ -3214,85 +2954,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-    },
-    "node_modules/@graphql-tools/graphql-tag-pluck": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-6.5.1.tgz",
-      "integrity": "sha512-7qkm82iFmcpb8M6/yRgzjShtW6Qu2OlCSZp8uatA3J0eMl87TxyJoUmL3M3UMMOSundAK8GmoyNVFUrueueV5Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "7.12.16",
-        "@babel/traverse": "7.12.13",
-        "@babel/types": "7.12.13",
-        "@graphql-tools/utils": "^7.0.0",
-        "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@babel/parser": {
-      "version": "7.12.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
-      "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@babel/traverse": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
-      "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.13",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@babel/types": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-      "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-      "dev": true
     },
     "node_modules/@graphql-tools/load": {
       "version": "7.8.14",
@@ -3372,104 +3033,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@graphql-tools/merge": {
-      "version": "6.2.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.14.tgz",
-      "integrity": "sha512-RWT4Td0ROJai2eR66NHejgf8UwnXJqZxXgDWDI+7hua5vNA2OW8Mf9K1Wav1ZkjWnuRp4ztNtkZGie5ISw55ow==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/schema": "^7.0.0",
-        "@graphql-tools/utils": "^7.7.0",
-        "tslib": "~2.2.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/merge/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-      "dev": true
-    },
-    "node_modules/@graphql-tools/optimize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.0.1.tgz",
-      "integrity": "sha512-cRlUNsbErYoBtzzS6zXahXeTBZGPVlPHXCpnEZ0XiK/KY/sQL96cyzak0fM/Gk6qEI9/l32MYEICjasiBQrl5w==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "~2.0.1"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/optimize/node_modules/tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-      "dev": true
-    },
-    "node_modules/@graphql-tools/relay-operation-optimizer": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.3.0.tgz",
-      "integrity": "sha512-Or3UgRvkY9Fq1AAx7q38oPqFmTepLz7kp6wDHKyR0ceG7AvHv5En22R12mAeISInbhff4Rpwgf6cE8zHRu6bCw==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/utils": "^7.1.0",
-        "relay-compiler": "10.1.0",
-        "tslib": "~2.0.1"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-      "dev": true
-    },
-    "node_modules/@graphql-tools/schema": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
-      "integrity": "sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/utils": "^7.1.2",
-        "tslib": "~2.2.0",
-        "value-or-promise": "1.0.6"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/schema/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-      "dev": true
-    },
-    "node_modules/@graphql-tools/utils": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.10.0.tgz",
-      "integrity": "sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==",
-      "dev": true,
-      "dependencies": {
-        "@ardatan/aggregate-error": "0.0.6",
-        "camel-case": "4.1.2",
-        "tslib": "~2.2.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/utils/node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-      "dev": true
     },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
@@ -13571,24 +13134,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/change-case-all": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.12.tgz",
-      "integrity": "sha512-zdQus7R0lkprF99lrWUC5bFj6Nog4Xt4YCEjQ/vM4vbc6b5JHFBQMxRPAjfx+HJH8WxMzH0E+lQ8yQJLgmPCBg==",
-      "dev": true,
-      "dependencies": {
-        "change-case": "^4.1.1",
-        "is-lower-case": "^2.0.1",
-        "is-upper-case": "^2.0.1",
-        "lower-case": "^2.0.1",
-        "lower-case-first": "^2.0.1",
-        "sponge-case": "^1.0.0",
-        "swap-case": "^2.0.1",
-        "title-case": "^3.0.2",
-        "upper-case": "^2.0.1",
-        "upper-case-first": "^2.0.1"
-      }
-    },
     "node_modules/change-case/node_modules/tslib": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
@@ -20238,37 +19783,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/gatsby-plugin-typegen": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-typegen/-/gatsby-plugin-typegen-2.2.4.tgz",
-      "integrity": "sha512-JWM4r5bv2wemCmBOzHKPaEwANvxl4fvtnyZw7XulhB1R3uMSDLsl1a0hPy27j23VdO5JROciZK0sqFgnweqJ4A==",
-      "dev": true,
-      "dependencies": {
-        "@cometjs/core": "^0.2.0",
-        "@graphql-codegen/core": "^1.17.9",
-        "@graphql-codegen/flow": "^1.18.3",
-        "@graphql-codegen/flow-operations": "^1.18.6",
-        "@graphql-codegen/flow-resolvers": "^1.17.13",
-        "@graphql-codegen/typescript": "^1.20.1",
-        "@graphql-codegen/typescript-operations": "^1.17.14",
-        "@graphql-codegen/typescript-resolvers": "^1.18.1",
-        "@graphql-tools/graphql-tag-pluck": "^6.3.0",
-        "@graphql-tools/utils": "^7.2.3",
-        "async": "^3.2.0",
-        "common-tags": "^1.8.0"
-      },
-      "peerDependencies": {
-        "gatsby": ">=2.0.0",
-        "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0",
-        "react": "^16.4.2 || ^17.0.0"
-      }
-    },
-    "node_modules/gatsby-plugin-typegen/node_modules/async": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-      "dev": true
-    },
     "node_modules/gatsby-plugin-typescript": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-4.25.0.tgz",
@@ -23972,18 +23486,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/import-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-      "dev": true,
-      "dependencies": {
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/import-lazy": {
@@ -32553,151 +32055,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/relay-compiler": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-10.1.0.tgz",
-      "integrity": "sha512-HPqc3N3tNgEgUH5+lTr5lnLbgnsZMt+MRiyS0uAVNhuPY2It0X1ZJG+9qdA3L9IqKFUNwVn6zTO7RArjMZbARQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.0.0",
-        "@babel/generator": "^7.5.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/runtime": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "babel-preset-fbjs": "^3.3.0",
-        "chalk": "^4.0.0",
-        "fb-watchman": "^2.0.0",
-        "fbjs": "^3.0.0",
-        "glob": "^7.1.1",
-        "immutable": "~3.7.6",
-        "nullthrows": "^1.1.1",
-        "relay-runtime": "10.1.0",
-        "signedsource": "^1.0.0",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "relay-compiler": "bin/relay-compiler"
-      },
-      "peerDependencies": {
-        "graphql": "^15.0.0"
-      }
-    },
-    "node_modules/relay-compiler/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/relay-compiler/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/relay-compiler/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/relay-compiler/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/relay-compiler/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/relay-compiler/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/relay-compiler/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/relay-compiler/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/relay-runtime": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-10.1.0.tgz",
-      "integrity": "sha512-bxznLnQ1ST6APN/cFi7l0FpjbZVchWQjjhj9mAuJBuUqNNCh9uV+UTRhpQF7Q8ycsPp19LHTpVyGhYb0ustuRQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "fbjs": "^3.0.0"
-      }
-    },
     "node_modules/remark": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
@@ -37704,15 +37061,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "node_modules/value-or-promise": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
-      "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -38660,23 +38008,6 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@ardatan/aggregate-error": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
-      "integrity": "sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
       }
     },
     "@aw-web-design/x-default-browser": {
@@ -40154,15 +39485,6 @@
       "dev": true,
       "optional": true
     },
-    "@cometjs/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@cometjs/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-H5G7/xYoHxmR4L4Pd77ScRCok2ttz7sG0BZ2B+pzsPammoIE63UiN2bCHjDOkXqbQplWU8xCiJBbHs3Cut2k/g==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.6.5"
-      }
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -40537,228 +39859,6 @@
         }
       }
     },
-    "@graphql-codegen/core": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-1.17.9.tgz",
-      "integrity": "sha512-7nwy+bMWqb0iYJ2DKxA9UiE16meeJ2Ch2XWS/N/ZnA0snTR+GZ20USI8z6YqP1Fuist7LvGO1MbitO2qBT8raA==",
-      "dev": true,
-      "requires": {
-        "@graphql-codegen/plugin-helpers": "^1.18.2",
-        "@graphql-tools/merge": "^6",
-        "@graphql-tools/utils": "^6",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "6.2.4",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.2.4.tgz",
-          "integrity": "sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==",
-          "dev": true,
-          "requires": {
-            "@ardatan/aggregate-error": "0.0.6",
-            "camel-case": "4.1.1",
-            "tslib": "~2.0.1"
-          }
-        },
-        "camel-case": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
-          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
-          "dev": true,
-          "requires": {
-            "pascal-case": "^3.1.1",
-            "tslib": "^1.10.0"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-              "dev": true
-            }
-          }
-        },
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-codegen/flow": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/flow/-/flow-1.18.5.tgz",
-      "integrity": "sha512-0VHG9twylPOlD8aq5lFU2j9K8ueubDwyOm3QYxshmCnjfwPG3xks+zqdTBR/A/jyNrCOPObfycIhotqyoSvn8w==",
-      "dev": true,
-      "requires": {
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-codegen/flow-operations": {
-      "version": "1.18.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/flow-operations/-/flow-operations-1.18.7.tgz",
-      "integrity": "sha512-yjbKD80erT7y591ZQJGBa5TRymc2mxTd+csFkv+JN+YKiiZXofH4CEs6GaiUq4B8/mg4RpKR/Yrq3AvCyj/c+A==",
-      "dev": true,
-      "requires": {
-        "@graphql-codegen/flow": "^1.18.5",
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-codegen/flow-resolvers": {
-      "version": "1.17.13",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/flow-resolvers/-/flow-resolvers-1.17.13.tgz",
-      "integrity": "sha512-crzdvOBtK0yvb7iXQdx9jBlO+b6+oT1n5DxEeKjZwKqPE/iVy0ooQbX3EoZb7Lci4KuF3DnnssF1Kn469tMRHQ==",
-      "dev": true,
-      "requires": {
-        "@graphql-codegen/flow": "^1.18.2",
-        "@graphql-codegen/plugin-helpers": "^1.18.2",
-        "@graphql-codegen/visitor-plugin-common": "^1.17.22",
-        "@graphql-tools/utils": "^7.0.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-codegen/plugin-helpers": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.18.4.tgz",
-      "integrity": "sha512-dpfhUmn9GOS8ByoOPIN3V4Nn9HX7sl9NR7Hf26TgN6Clg7cQvkT6XjHdS2e56Q3kWrxZT1zJ1sEa67D3tj9ZtQ==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/utils": "^7.0.0",
-        "common-tags": "1.8.0",
-        "import-from": "3.0.0",
-        "lodash": "~4.17.20",
-        "tslib": "~2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-codegen/typescript": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-1.21.1.tgz",
-      "integrity": "sha512-JF6Vsu5HSv3dAoS2ca3PFLUN0qVxotex/+BgWw/6SKhtd83MUPnzJ/RU3lACg4vuNTCWeQSeGvg8x5qrw9Go9w==",
-      "dev": true,
-      "requires": {
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-codegen/typescript-operations": {
-      "version": "1.17.15",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-1.17.15.tgz",
-      "integrity": "sha512-HStWj3mUe+0ir2J0jqgjegrvcO1DIe2gzsoBBo9RHIYwyaxedUivxXvWY9XBfKpHv6sLa/ST1iYGeedrJELPtw==",
-      "dev": true,
-      "requires": {
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/typescript": "^1.21.1",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-codegen/typescript-resolvers": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-1.19.0.tgz",
-      "integrity": "sha512-37dkn4f3xcvsMQVatpiL2/r/qpjOyu/HCiJhsZuxLpQaBk7Z+z9nogawt4zxk7ZODpViN1zNO2hS7lLXEGmbZw==",
-      "dev": true,
-      "requires": {
-        "@graphql-codegen/plugin-helpers": "^1.18.3",
-        "@graphql-codegen/typescript": "^1.21.1",
-        "@graphql-codegen/visitor-plugin-common": "^1.19.0",
-        "@graphql-tools/utils": "^7.0.0",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-codegen/visitor-plugin-common": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.19.1.tgz",
-      "integrity": "sha512-MJZXe5vXxV6PLOgHhQoz93gnjzJtbnVQXQKqVEcbyB9W8ImoKuTHsEf/eJ6yCL79f7X/2dnOOM84d5Osh1eaKg==",
-      "dev": true,
-      "requires": {
-        "@graphql-codegen/plugin-helpers": "^1.18.4",
-        "@graphql-tools/optimize": "^1.0.1",
-        "@graphql-tools/relay-operation-optimizer": "^6",
-        "array.prototype.flatmap": "^1.2.4",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.12",
-        "dependency-graph": "^0.11.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "~2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
-        }
-      }
-    },
     "@graphql-tools/code-file-loader": {
       "version": "7.3.23",
       "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-7.3.23.tgz",
@@ -40797,70 +39897,6 @@
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
           "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        }
-      }
-    },
-    "@graphql-tools/graphql-tag-pluck": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-6.5.1.tgz",
-      "integrity": "sha512-7qkm82iFmcpb8M6/yRgzjShtW6Qu2OlCSZp8uatA3J0eMl87TxyJoUmL3M3UMMOSundAK8GmoyNVFUrueueV5Q==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "7.12.16",
-        "@babel/traverse": "7.12.13",
-        "@babel/types": "7.12.13",
-        "@graphql-tools/utils": "^7.0.0",
-        "tslib": "~2.1.0"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.12.16",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.16.tgz",
-          "integrity": "sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
-          "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.12.13",
-            "@babel/helper-function-name": "^7.12.13",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.19"
-          }
-        },
-        "@babel/types": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-          "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
         }
       }
     },
@@ -40921,99 +39957,6 @@
           "version": "1.0.12",
           "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
           "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q=="
-        }
-      }
-    },
-    "@graphql-tools/merge": {
-      "version": "6.2.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.14.tgz",
-      "integrity": "sha512-RWT4Td0ROJai2eR66NHejgf8UwnXJqZxXgDWDI+7hua5vNA2OW8Mf9K1Wav1ZkjWnuRp4ztNtkZGie5ISw55ow==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/schema": "^7.0.0",
-        "@graphql-tools/utils": "^7.7.0",
-        "tslib": "~2.2.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/optimize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.0.1.tgz",
-      "integrity": "sha512-cRlUNsbErYoBtzzS6zXahXeTBZGPVlPHXCpnEZ0XiK/KY/sQL96cyzak0fM/Gk6qEI9/l32MYEICjasiBQrl5w==",
-      "dev": true,
-      "requires": {
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/relay-operation-optimizer": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.3.0.tgz",
-      "integrity": "sha512-Or3UgRvkY9Fq1AAx7q38oPqFmTepLz7kp6wDHKyR0ceG7AvHv5En22R12mAeISInbhff4Rpwgf6cE8zHRu6bCw==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/utils": "^7.1.0",
-        "relay-compiler": "10.1.0",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/schema": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
-      "integrity": "sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/utils": "^7.1.2",
-        "tslib": "~2.2.0",
-        "value-or-promise": "1.0.6"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/utils": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.10.0.tgz",
-      "integrity": "sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==",
-      "dev": true,
-      "requires": {
-        "@ardatan/aggregate-error": "0.0.6",
-        "camel-case": "4.1.2",
-        "tslib": "~2.2.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-          "dev": true
         }
       }
     },
@@ -48235,24 +47178,6 @@
         }
       }
     },
-    "change-case-all": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.12.tgz",
-      "integrity": "sha512-zdQus7R0lkprF99lrWUC5bFj6Nog4Xt4YCEjQ/vM4vbc6b5JHFBQMxRPAjfx+HJH8WxMzH0E+lQ8yQJLgmPCBg==",
-      "dev": true,
-      "requires": {
-        "change-case": "^4.1.1",
-        "is-lower-case": "^2.0.1",
-        "is-upper-case": "^2.0.1",
-        "lower-case": "^2.0.1",
-        "lower-case-first": "^2.0.1",
-        "sponge-case": "^1.0.0",
-        "swap-case": "^2.0.1",
-        "title-case": "^3.0.2",
-        "upper-case": "^2.0.1",
-        "upper-case-first": "^2.0.1"
-      }
-    },
     "char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -54824,34 +53749,6 @@
         }
       }
     },
-    "gatsby-plugin-typegen": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-typegen/-/gatsby-plugin-typegen-2.2.4.tgz",
-      "integrity": "sha512-JWM4r5bv2wemCmBOzHKPaEwANvxl4fvtnyZw7XulhB1R3uMSDLsl1a0hPy27j23VdO5JROciZK0sqFgnweqJ4A==",
-      "dev": true,
-      "requires": {
-        "@cometjs/core": "^0.2.0",
-        "@graphql-codegen/core": "^1.17.9",
-        "@graphql-codegen/flow": "^1.18.3",
-        "@graphql-codegen/flow-operations": "^1.18.6",
-        "@graphql-codegen/flow-resolvers": "^1.17.13",
-        "@graphql-codegen/typescript": "^1.20.1",
-        "@graphql-codegen/typescript-operations": "^1.17.14",
-        "@graphql-codegen/typescript-resolvers": "^1.18.1",
-        "@graphql-tools/graphql-tag-pluck": "^6.3.0",
-        "@graphql-tools/utils": "^7.2.3",
-        "async": "^3.2.0",
-        "common-tags": "^1.8.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-          "dev": true
-        }
-      }
-    },
     "gatsby-plugin-typescript": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-4.25.0.tgz",
@@ -56094,15 +54991,6 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         }
-      }
-    },
-    "import-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-      "dev": true,
-      "requires": {
-        "resolve-from": "^5.0.0"
       }
     },
     "import-lazy": {
@@ -62620,126 +61508,6 @@
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
       "dev": true
     },
-    "relay-compiler": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-10.1.0.tgz",
-      "integrity": "sha512-HPqc3N3tNgEgUH5+lTr5lnLbgnsZMt+MRiyS0uAVNhuPY2It0X1ZJG+9qdA3L9IqKFUNwVn6zTO7RArjMZbARQ==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.0.0",
-        "@babel/generator": "^7.5.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/runtime": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "babel-preset-fbjs": "^3.3.0",
-        "chalk": "^4.0.0",
-        "fb-watchman": "^2.0.0",
-        "fbjs": "^3.0.0",
-        "glob": "^7.1.1",
-        "immutable": "~3.7.6",
-        "nullthrows": "^1.1.1",
-        "relay-runtime": "10.1.0",
-        "signedsource": "^1.0.0",
-        "yargs": "^15.3.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "dev": true,
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
-    "relay-runtime": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-10.1.0.tgz",
-      "integrity": "sha512-bxznLnQ1ST6APN/cFi7l0FpjbZVchWQjjhj9mAuJBuUqNNCh9uV+UTRhpQF7Q8ycsPp19LHTpVyGhYb0ustuRQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "fbjs": "^3.0.0"
-      }
-    },
     "remark": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
@@ -66593,12 +65361,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-or-promise": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.6.tgz",
-      "integrity": "sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==",
-      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "gatsby-plugin-sass": "^5.25.0",
     "gatsby-plugin-sharp": "^4.25.1",
     "gatsby-plugin-ts-checker": "^1.1.0",
-    "gatsby-plugin-typegen": "^2.2.4",
     "gatsby-source-filesystem": "^4.25.0",
     "gatsby-transformer-sharp": "^4.25.0",
     "identity-obj-proxy": "^3.0.0",

--- a/src/components/inline/PrimsicLink.tsx
+++ b/src/components/inline/PrimsicLink.tsx
@@ -10,7 +10,7 @@ import React from "react";
  * to a link.
  */
 export type MinimalPrismicLinkType = Pick<
-  GatsbyTypes.PrismicLinkType,
+  Queries.PrismicLinkType,
   "link_type" | "target" | "url"
 >;
 
@@ -34,7 +34,7 @@ const PrismicLink = ({ linkData, children }: PrismicLinkProps): JSX.Element => {
     case "Web":
     case "Media":
       return (
-        <a href={linkData.url} target={linkData.target}>
+        <a href={linkData.url} target={linkData.target ?? undefined}>
           {children}
         </a>
       );

--- a/src/pages/blog/{prismicBlogPost.uid}.tsx
+++ b/src/pages/blog/{prismicBlogPost.uid}.tsx
@@ -126,20 +126,25 @@ export const query = graphql`
 export const PrismicBlogPostPage = ({
   data,
   location,
-}: PageProps<GatsbyTypes.PrismicBlogPostQuery>) => {
+}: PageProps<Queries.PrismicBlogPostQuery>) => {
   if (!data?.prismicBlogPost?.data) return <h1>There was a problem</h1>;
   const blogData = data.prismicBlogPost.data;
   const slices = blogData?.body ?? [];
+  const topicDocument = blogData?.topic?.document;
 
   return (
     <BlogPostTemplate
       pageUrl={location.pathname}
-      title={blogData?.title?.text}
-      author={blogData?.author?.text}
-      topic={blogData?.topic?.document?.data?.name?.text}
-      date={blogData?.publish_date}
-      headerImgAlt={blogData?.header_image?.alt}
-      headerImgUrl={blogData?.header_image?.url}
+      title={blogData?.title?.text ?? undefined}
+      author={blogData?.author?.text ?? undefined}
+      topic={
+        topicDocument && "data" in topicDocument
+          ? topicDocument.data?.name?.text ?? undefined
+          : undefined
+      }
+      date={blogData?.publish_date ?? undefined}
+      headerImgAlt={blogData?.header_image?.alt ?? undefined}
+      headerImgUrl={blogData?.header_image?.url ?? undefined}
       slices={slices}
     />
   );


### PR DESCRIPTION
Refs #365.

Gatsby 4.15 has a built-in feature for generating TypeScript type stubs for GraphQL queries within an app. gatsby-plugin-typegen is no longer maintained, and it's currently blocking some upgrades of other packages because it declares a conflicting NPM peer dependency on graphql.

This commit removes gatsby-plugin-typegen, and it enables the new built-in type stub generation as described in
https://www.gatsbyjs.com/docs/how-to/local-development/graphql-typegen/. Since the new types are not 100% compatible with the previous ones, this commit also includes changes for migrating to the new types.

One issue with the new types is that they are very precise, which actually causes some code to be unnecessarily verbose. In particular, in all instances of inline fragments (the `... on TypeName`) expressions, the generated types infer a pessimistic fallback type of `{}` for the case where an object doesn't match any of the explicit type cases. This makes it impossible to option chaining syntax (`?.`), since TypeScript errs on the side of reporting an error when not all objects in a union declare a property.

For a concrete example, suppose we have the GraphQL query:

```graphql
{
  foo {
    ... on Bar {
      bar
    }
  }
}
```

and suppose we have the inferred TypeScript type:

```typescript
{
  foo: { bar: string } | {} | null
}
```

The following expression contains a type error:

```typescript
foo?.bar
```

This is because `foo` could be `{}`, and the `{}` type in TypeScript could be any object with any properties, _not_ the empty object with no properties.

We can work around this issue by performing an explicit key check:

```typescript
"bar" in foo ? foo.bar : undefined
```

This gets pretty verbose when we have heavily nested objects, but it's not clear if we have any other option for working around this, barring turning off automatic type generation for GraphQL queries. For now, we employ the workaround, but if this proves to be too onerous, we should just disable the GraphQL type stub generation.