### PR TITLE
Migrate off react-helmet and onto Gatsby Head.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,7 +10,6 @@ module.exports = {
     author: "ShelterTech",
   },
   plugins: [
-    "gatsby-plugin-react-helmet",
     "gatsby-plugin-ts-checker",
     {
       resolve: "gatsby-plugin-intercom-spa",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "pure-react-carousel": "^1.27.6",
         "react": "^16.13.1",
         "react-burger-menu": "^2.9.0",
-        "react-helmet": "^6.1.0",
         "react-modal": "^3.11.2"
       },
       "devDependencies": {
@@ -36,7 +35,6 @@
         "@types/react": "^17.0.0",
         "@types/react-burger-menu": "^2.8.0",
         "@types/react-dom": "^17.0.0",
-        "@types/react-helmet": "^6.1.1",
         "@types/react-modal": "^3.12.0",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
@@ -55,7 +53,6 @@
         "gatsby-plugin-intercom-spa": "^0.2.0",
         "gatsby-plugin-manifest": "^4.25.0",
         "gatsby-plugin-postcss": "^5.25.0",
-        "gatsby-plugin-react-helmet": "^5.25.0",
         "gatsby-plugin-sharp": "^4.25.1",
         "gatsby-plugin-ts-checker": "^1.1.0",
         "gatsby-source-filesystem": "^4.25.0",
@@ -9833,15 +9830,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/react-helmet": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.1.tgz",
-      "integrity": "sha512-VmSCMz6jp/06DABoY60vQa++h1YFt0PfAI23llxBJHbowqFgLUL0dhS1AQeVPNqYfRp9LAfokrfWACTNeobOrg==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/react-modal": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.12.0.tgz",
@@ -18575,22 +18563,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/gatsby-plugin-react-helmet": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-5.25.0.tgz",
-      "integrity": "sha512-sU/xae/sGuYFcFDpqUxwXnaOmx8xrU2Q+XSULqAapji0uTBhW6al6CJsaPFigi8IOG2bQX8ano2iWWcGF3/GHw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^4.0.0-next",
-        "react-helmet": "^5.1.3 || ^6.0.0"
-      }
     },
     "node_modules/gatsby-plugin-sharp": {
       "version": "4.25.1",
@@ -28623,11 +28595,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
     "node_modules/react-focus-lock": {
       "version": "2.9.5",
       "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
@@ -28648,20 +28615,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
       }
     },
     "node_modules/react-inspector": {
@@ -28763,14 +28716,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/react-side-effect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0"
-      }
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
@@ -41063,15 +41008,6 @@
         "@types/react": "*"
       }
     },
-    "@types/react-helmet": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.1.tgz",
-      "integrity": "sha512-VmSCMz6jp/06DABoY60vQa++h1YFt0PfAI23llxBJHbowqFgLUL0dhS1AQeVPNqYfRp9LAfokrfWACTNeobOrg==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/react-modal": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.12.0.tgz",
@@ -48572,15 +48508,6 @@
         }
       }
     },
-    "gatsby-plugin-react-helmet": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-5.25.0.tgz",
-      "integrity": "sha512-sU/xae/sGuYFcFDpqUxwXnaOmx8xrU2Q+XSULqAapji0uTBhW6al6CJsaPFigi8IOG2bQX8ano2iWWcGF3/GHw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.15.4"
-      }
-    },
     "gatsby-plugin-sharp": {
       "version": "4.25.1",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-4.25.1.tgz",
@@ -55338,11 +55265,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
-    "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
     "react-focus-lock": {
       "version": "2.9.5",
       "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
@@ -55354,17 +55276,6 @@
         "react-clientside-effect": "^1.2.6",
         "use-callback-ref": "^1.3.0",
         "use-sidecar": "^1.1.2"
-      }
-    },
-    "react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
       }
     },
     "react-inspector": {
@@ -55434,12 +55345,6 @@
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
-    },
-    "react-side-effect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
-      "requires": {}
     },
     "react-style-singleton": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "pure-react-carousel": "^1.27.6",
     "react": "^16.13.1",
     "react-burger-menu": "^2.9.0",
-    "react-helmet": "^6.1.0",
     "react-modal": "^3.11.2"
   },
   "devDependencies": {
@@ -55,7 +54,6 @@
     "@types/react": "^17.0.0",
     "@types/react-burger-menu": "^2.8.0",
     "@types/react-dom": "^17.0.0",
-    "@types/react-helmet": "^6.1.1",
     "@types/react-modal": "^3.12.0",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
@@ -74,7 +72,6 @@
     "gatsby-plugin-intercom-spa": "^0.2.0",
     "gatsby-plugin-manifest": "^4.25.0",
     "gatsby-plugin-postcss": "^5.25.0",
-    "gatsby-plugin-react-helmet": "^5.25.0",
     "gatsby-plugin-sharp": "^4.25.1",
     "gatsby-plugin-ts-checker": "^1.1.0",
     "gatsby-source-filesystem": "^4.25.0",

--- a/src/components/BaseHead.tsx
+++ b/src/components/BaseHead.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import favicon from "./favicon.ico";
+
+type Props = {
+  title: string | null;
+};
+
+/** Base component for the <head> element on each page.
+ *
+ * This uses the Gatsby Head API, which involves declaring an export named
+ * `Head` in each file describing a page (e.g. src/pages). Note that unlike
+ * react-helmet, nested, duplicated tags aren't automatically deduplicated, so
+ * if we need to override a tag defined in this component, we need to declare
+ * `id` properties. To add additional tags, you can simply instantiate this
+ * component and add the other tags as sibling elements.
+ *
+ * See the Gatsby documentation for more details:
+ * https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/
+ */
+const BaseHead = ({ title }: Props) => (
+  <>
+    <meta charSet="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0"
+    />
+
+    {title && <title>{title}</title>}
+    <meta
+      name="description"
+      content="ShelterTech is solving the biggest technology challenges faced by those experiencing homelessness"
+    />
+    <meta name="twitter:site" content="@sheltertechorg" />
+    <link rel="icon" href={favicon} />
+    {/* Global site tag (gtag.js) - Google Analytics */}
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-116318550-4"
+    />
+    <script>{`
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-116318550-4');
+    `}</script>
+  </>
+);
+
+export default BaseHead;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect } from "react";
-import { Helmet } from "react-helmet";
 import ReactModal from "react-modal";
 
 import "../stylesheets/global.css";
-import favicon from "./favicon.ico";
 import Footer from "./grid-aware/Footer";
 import shelterTechLogoWhite from "./grid-aware/Footer/sheltertech-logo-white.svg";
 import facebookLogo from "./grid-aware/Footer/stories/facebook.svg";
@@ -42,33 +40,6 @@ const Layout = ({ children }: LayoutProps) => {
 
   return (
     <div id={outerContainerID}>
-      <Helmet>
-        <meta charSet="utf-8" />
-        <meta
-          name="viewport"
-          content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0"
-        />
-
-        <title>ShelterTech - Technology for the under-resourced</title>
-        <meta
-          name="description"
-          content="ShelterTech is solving the biggest technology challenges faced by those experiencing homelessness"
-        />
-        <meta name="twitter:site" content="@sheltertechorg" />
-        <link rel="icon" href={favicon} />
-        {/* Global site tag (gtag.js) - Google Analytics */}
-        <script
-          async
-          src="https://www.googletagmanager.com/gtag/js?id=UA-116318550-4"
-        />
-        <script>{`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', 'UA-116318550-4');
-        `}</script>
-      </Helmet>
       <BurgerMenu
         isOpen={burgerMenuIsOpen}
         setIsOpen={setBurgerMenuIsOpen}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,6 +1,7 @@
 import { withPrismicUnpublishedPreview } from "gatsby-plugin-prismic-previews";
 import React from "react";
 
+import BaseHead from "../components/BaseHead";
 import OneParagraphBlock from "../components/grid-aware/OneParagraphBlock";
 import Spacer from "../components/grid-aware/Spacer";
 import Layout from "../components/layout";
@@ -20,3 +21,5 @@ const NotFoundPage = () => (
 );
 
 export default withPrismicUnpublishedPreview(NotFoundPage);
+
+export const Head = () => <BaseHead title="Page Not Found | ShelterTech" />;

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { Helmet } from "react-helmet";
 
+import BaseHead from "../../components/BaseHead";
 import ArticleSpotlightCard from "../../components/grid-aware/ArticleSpotlightCard";
 import ImageHeader from "../../components/grid-aware/ImageHeader";
 import Spacer from "../../components/grid-aware/Spacer";
@@ -12,9 +12,6 @@ import teamImage from "./sheltertech-team.png";
 
 export default () => (
   <Layout>
-    <Helmet>
-      <title>About Us | ShelterTech</title>
-    </Helmet>
     <ImageHeader
       title="About Us"
       subtitle="Our Mission and History"
@@ -106,3 +103,5 @@ export default () => (
     <Spacer heightDesktop="170px" heightMobile="80px" />
   </Layout>
 );
+
+export const Head = () => <BaseHead title="About Us | ShelterTech" />;

--- a/src/pages/blog/{prismicBlogPost.uid}.tsx
+++ b/src/pages/blog/{prismicBlogPost.uid}.tsx
@@ -1,6 +1,7 @@
 import { graphql, PageProps } from "gatsby";
 import { withPrismicPreview } from "gatsby-plugin-prismic-previews";
 import React from "react";
+import BaseHead from "../../components/BaseHead";
 import BlogPostTemplate from "../../templates/BlogPostTemplate";
 
 /**
@@ -125,7 +126,6 @@ export const query = graphql`
 
 export const PrismicBlogPostPage = ({
   data,
-  location,
 }: PageProps<Queries.PrismicBlogPostQuery>) => {
   if (!data?.prismicBlogPost?.data) return <h1>There was a problem</h1>;
   const blogData = data.prismicBlogPost.data;
@@ -134,7 +134,6 @@ export const PrismicBlogPostPage = ({
 
   return (
     <BlogPostTemplate
-      pageUrl={location.pathname}
       title={blogData?.title?.text ?? undefined}
       author={blogData?.author?.text ?? undefined}
       topic={
@@ -151,3 +150,30 @@ export const PrismicBlogPostPage = ({
 };
 
 export default withPrismicPreview(PrismicBlogPostPage);
+
+export const Head = ({
+  data,
+  location,
+}: PageProps<Queries.PrismicBlogPostQuery>) => {
+  if (!data?.prismicBlogPost?.data)
+    return <BaseHead title="There was a problem | ShelterTech" />;
+  const blogData = data.prismicBlogPost.data;
+  const title = blogData?.title?.text ?? undefined;
+  const headerImgUrl = blogData?.header_image?.url ?? undefined;
+  return (
+    <>
+      <BaseHead title={title ? `${title} | ShelterTech` : null} />
+      {title && <meta property="og:title" content={title} />}
+      <meta property="og:type" content="article" />
+      <meta
+        property="og:url"
+        content={`https://sheltertech.org${location.pathname}`}
+      />
+      <meta
+        name="twitter:card"
+        content={headerImgUrl ? "summary_large_image" : "summary"}
+      />
+      {headerImgUrl && <meta property="og:image" content={headerImgUrl} />}
+    </>
+  );
+};

--- a/src/pages/donate/index.tsx
+++ b/src/pages/donate/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { Helmet } from "react-helmet";
 
+import BaseHead from "../../components/BaseHead";
 import ArticleSpotlightCard from "../../components/grid-aware/ArticleSpotlightCard";
 import DonationBlock from "../../components/grid-aware/DonationBlock";
 import Spacer from "../../components/grid-aware/Spacer";
@@ -9,9 +9,6 @@ import articleSpotlightImage from "../images/mission-hotel.jpeg";
 
 export default () => (
   <Layout>
-    <Helmet>
-      <title>Donate | ShelterTech</title>
-    </Helmet>
     <DonationBlock
       mainTitle="Donate today"
       mainDescription="Your support will address digital inequity for an under-resourced community that does not have access to the internet and essential digital services."
@@ -45,3 +42,5 @@ export default () => (
     <Spacer heightDesktop="170px" heightMobile="80px" />
   </Layout>
 );
+
+export const Head = () => <BaseHead title="Donate | ShelterTech" />;

--- a/src/pages/impact/index.tsx
+++ b/src/pages/impact/index.tsx
@@ -1,7 +1,7 @@
 import { Link } from "gatsby";
 import * as React from "react";
-import { Helmet } from "react-helmet";
 
+import BaseHead from "../../components/BaseHead";
 import ArticleSpotlightCard from "../../components/grid-aware/ArticleSpotlightCard";
 import Spacer from "../../components/grid-aware/Spacer";
 import StatsBarBlock from "../../components/grid-aware/StatsBarBlock";
@@ -14,9 +14,6 @@ import our415Logo from "./our-415-logo.svg";
 
 export default () => (
   <Layout>
-    <Helmet>
-      <title>Making an Impact</title>
-    </Helmet>
     <TextHeader title="Making an Impact" hasBottomPadding={false} />
     <StatsBlock
       title="SF Service Guide"
@@ -152,3 +149,5 @@ export default () => (
     <Spacer heightDesktop="170px" heightMobile="80px" />
   </Layout>
 );
+
+export const Head = () => <BaseHead title="Making an Impact | ShelterTech" />;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 
+import BaseHead from "../components/BaseHead";
 import YouTubeEmbed from "../components/block/YouTubeEmbed";
 import ArticleSpotlightCard from "../components/grid-aware/ArticleSpotlightCard";
 import BlockQuoteBlock from "../components/grid-aware/BlockQuoteBlock/BlockQuoteBlock";
@@ -186,3 +187,7 @@ export default () => {
     </Layout>
   );
 };
+
+export const Head = () => (
+  <BaseHead title="ShelterTech - Technology for the under-resourced" />
+);

--- a/src/pages/programs/index.tsx
+++ b/src/pages/programs/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 
+import BaseHead from "../../components/BaseHead";
 import ArticleSpotlightCard from "../../components/grid-aware/ArticleSpotlightCard";
 import Modal from "../../components/grid-aware/Modal";
 import ProgramBlock from "../../components/grid-aware/ProgramBlock";
@@ -165,3 +166,5 @@ export default () => {
     </Layout>
   );
 };
+
+export const Head = () => <BaseHead title="Our Programs | ShelterTech" />;

--- a/src/pages/volunteer/index.tsx
+++ b/src/pages/volunteer/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Helmet } from "react-helmet";
 
+import BaseHead from "../../components/BaseHead";
 import ArticleSpotlightCard from "../../components/grid-aware/ArticleSpotlightCard";
 import COVID19infoBoxBlock from "../../components/grid-aware/COVID19InfoBoxBlock";
 import ImageHeader from "../../components/grid-aware/ImageHeader";
@@ -22,9 +22,6 @@ export default () => {
   const [volunteerFormIsOpen, setVolunteerFormIsOpen] = useState(false);
   return (
     <Layout>
-      <Helmet>
-        <title>Volunteer | ShelterTech</title>
-      </Helmet>
       <Modal
         isOpen={volunteerFormIsOpen}
         setIsOpen={setVolunteerFormIsOpen}
@@ -192,3 +189,5 @@ export default () => {
     </Layout>
   );
 };
+
+export const Head = () => <BaseHead title="Volunteer | ShelterTech" />;

--- a/src/templates/BlogIndexTemplate/blogIndexTemplate.tsx
+++ b/src/templates/BlogIndexTemplate/blogIndexTemplate.tsx
@@ -1,7 +1,7 @@
 import { graphql, PageProps } from "gatsby";
 import React from "react";
-import { Helmet } from "react-helmet";
 
+import BaseHead from "../../components/BaseHead";
 import BlogPostSummaryCard from "../../components/blog/BlogPostSummaryCard";
 import Pagination from "../../components/blog/Pagination";
 import TopicFilterMenu from "../../components/blog/TopicFilterMenu";
@@ -119,9 +119,6 @@ export default ({
   });
   return (
     <Layout>
-      <Helmet>
-        <title>Stories | ShelterTech</title>
-      </Helmet>
       <TextHeader
         title="ShelterTech Stories"
         description="The official blog of ShelterTech, an all-volunteer non-profit creating technology for people experiencing homelessness. Made with love in SF."
@@ -165,3 +162,5 @@ export default ({
     </Layout>
   );
 };
+
+export const Head = () => <BaseHead title="Stories | ShelterTech" />;

--- a/src/templates/BlogPostTemplate/blogPostTemplate.tsx
+++ b/src/templates/BlogPostTemplate/blogPostTemplate.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Helmet } from "react-helmet";
+
 import ButtonBlock from "../../components/blog/ButtonBlock";
 import ImageBlock from "../../components/blog/ImageBlock";
 import LogoSeparator from "../../components/blog/LogoSeparator";
@@ -11,9 +11,6 @@ import Spacer from "../../components/grid-aware/Spacer";
 import Layout from "../../components/layout";
 
 type BlogPostTemplateProps = {
-  // The URL to this page, excluding the domain name. Should start with a
-  // leading "/".
-  pageUrl: string;
   topic?: string;
   title?: string;
   author?: string;
@@ -25,7 +22,6 @@ type BlogPostTemplateProps = {
 
 /** The JSX template we render for each blog post. */
 const BlogPostTemplate = ({
-  pageUrl,
   topic,
   title,
   author,
@@ -105,17 +101,6 @@ const BlogPostTemplate = ({
 
   return (
     <Layout>
-      <Helmet>
-        {title && <title>{title} | ShelterTech</title>}
-        {title && <meta property="og:title" content={title} />}
-        <meta property="og:type" content="article" />
-        <meta property="og:url" content={`https://sheltertech.org${pageUrl}`} />
-        <meta
-          name="twitter:card"
-          content={headerImgUrl ? "summary_large_image" : "summary"}
-        />
-        {headerImgUrl && <meta property="og:image" content={headerImgUrl} />}
-      </Helmet>
       <Spacer heightDesktop="80px" heightMobile="50px" />
       <TitleBlock
         topic={topic}


### PR DESCRIPTION
gatsby-plugin-react-helmet is deprecated, and the version of react-helmet we were using was causing some minor issues with upgrading the version of React. Since Gatsby is deprecating its official support for react-helmet, it may be easier to just migrate to Gatsby's new builtin Head API, which provides similar functionality.

This follows the instructions in the official documentation[^1] for using the Head API. The main difference from react-helmet is that instead of defining a base `<Helmet>` tag that can be overwritten on individual pages through nested `<Helmet>` tags, the Head API requires exporting a separate `<Head>` component on each page. Although there is no built-in overrides system, since it just uses plain React components under the hood, we can build our own, simple system.

We define a `BaseHead` component with all the common tags, and we also have a mandatory `title` prop, which serves as a reminder for each page to explicitly define its title. Almost every page today only overrides the `title`, so this is mostly sufficient. The one exception is the Blog Post template, which is used to dynamically generate pages based on the results of GraphQL API queries. On that page, in addition to instantiating the `BaseHead` component, we add a number of sibling elements, using page data that Gatsby passes into the `Head` component.

This also adds in the missing title for the Programs page, which was missing under the react-helmet implementation.

[^1]: https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/