### PR TITLE
Use new Candid (formerly GuideStar) seal.

### DIFF
--- a/src/components/grid-aware/Footer/NavigationBlock/NavigationBlock.module.css
+++ b/src/components/grid-aware/Footer/NavigationBlock/NavigationBlock.module.css
@@ -61,8 +61,8 @@
 }
 
 .sealImage {
-  height: 60px;
-  width: 60px;
+  height: 80px;
+  width: 80px;
 }
 
 @media (--tablet-and-down) {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -6,7 +6,6 @@ import Footer from "./grid-aware/Footer";
 import shelterTechLogoWhite from "./grid-aware/Footer/sheltertech-logo-white.svg";
 import facebookLogo from "./grid-aware/Footer/stories/facebook.svg";
 import githubLogo from "./grid-aware/Footer/stories/github.svg";
-import sealOfTransparency from "./grid-aware/Footer/stories/guidestar-seal-of-transparency.svg";
 import instagramLogo from "./grid-aware/Footer/stories/instagram.svg";
 import twitterLogo from "./grid-aware/Footer/stories/twitter.svg";
 import { BurgerMenu, Navigation } from "./grid-aware/Navigation";
@@ -70,8 +69,8 @@ const Layout = ({ children }: LayoutProps) => {
           ]}
           seals={[
             {
-              link: "https://www.guidestar.org/profile/38-3984099",
-              logo: sealOfTransparency,
+              link: "https://www.guidestar.org/profile/shared/e23fc5a4-2f66-4562-8c4e-e3d813e732b5",
+              logo: "https://widgets.guidestar.org/TransparencySeal/9546530",
               alt: "GuideStar Seal of Transparency",
             },
           ]}


### PR DESCRIPTION
This is also a direct link to an image on their website, so it should automatically update when our status changes in the future, which will avoid having to make a code change to update this.

Also, this bumps up the image size slightly, from 60px to 80px. The text was difficult to read at 60px, even with the old GuideStar seal, so we want to increase it a bit. We still want it to be smaller than our own logo in the footer, so 80px is a reasonable middle ground.

**Before**
<img width="632" alt="Screenshot 2024-02-21 at 8 26 04 PM" src="https://github.com/ShelterTechSF/sheltertech.org/assets/1002748/46c6ad89-20c8-4cc3-8100-9374119fd998">


**After**

<img width="631" alt="Screenshot 2024-02-21 at 8 25 32 PM" src="https://github.com/ShelterTechSF/sheltertech.org/assets/1002748/be62f02d-5375-4f3f-831a-69ca0550190f">